### PR TITLE
Create jsPlumb React wrapper library

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+node_modules
+.dist
+.DS_Store
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+# Build output
+dist

--- a/README.md
+++ b/README.md
@@ -1,1 +1,66 @@
 # jsplumb-react-wrapper
+
+A React + TypeScript wrapper around the [@jsplumb/community](https://www.jsplumb.org/) library that exposes a declarative API for building node/link diagrams. It provides helpers for rendering custom React nodes, managing ports, creating connections and tracking selection, while keeping full control in React state.
+
+## Features
+
+- Render nodes with arbitrary React JSX layouts and custom metadata.
+- Support for multiple ports per node with source/target/bidirectional modes.
+- Drag nodes, create links, detach links and receive callbacks for user actions.
+- Built-in multi-selection for nodes and links (Cmd/Ctrl/Shift click).
+- Zoom, pan and programmatic focus helpers exposed through a React ref.
+- Hover actions with delete buttons for nodes and links using pure CSS.
+- Event callbacks for click, double click, creation and deletion.
+- TypeScript definitions for all public APIs.
+- Playground powered by Vite (`npm run dev`) using fake data.
+
+## Getting started
+
+Install peer dependencies and the package:
+
+```bash
+npm install react react-dom @jsplumb/community jsplumb-react-wrapper
+```
+
+Render a canvas by providing nodes and connections:
+
+```tsx
+import { FlowCanvas, type FlowNode, type FlowConnection } from 'jsplumb-react-wrapper';
+
+const nodes: FlowNode[] = [
+  {
+    id: 'node-a',
+    position: { x: 120, y: 160 },
+    render: ({ selected }) => (
+      <div>
+        <h3>API Request</h3>
+        {selected && <strong>Selected</strong>}
+      </div>
+    ),
+    ports: [{ id: 'out', mode: 'source', label: '→' }]
+  },
+  {
+    id: 'node-b',
+    position: { x: 420, y: 160 },
+    render: <h3>Process</h3>,
+    ports: [{ id: 'in', mode: 'target', label: '←' }]
+  }
+];
+
+const connections: FlowConnection[] = [
+  { id: 'edge-1', source: { nodeId: 'node-a', portId: 'out' }, target: { nodeId: 'node-b', portId: 'in' } }
+];
+
+<FlowCanvas nodes={nodes} connections={connections} />;
+```
+
+## Development
+
+- `npm run dev` – starts the Vite playground with a sample flow editor.
+- `npm run build` – generates TypeScript declarations and the library bundle (Vite library mode).
+
+The playground is located under `src/dev` and demonstrates how to wire the callbacks to maintain state entirely in React.
+
+## License
+
+MIT

--- a/index.html
+++ b/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>jsPlumb React Wrapper Playground</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/dev/main.tsx"></script>
+  </body>
+</html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,1321 @@
+{
+  "name": "jsplumb-react-wrapper",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "jsplumb-react-wrapper",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@jsplumb/community": "^4.0.0-RC47",
+        "@jsplumb/core": "^4.0.0-RC47"
+      },
+      "devDependencies": {
+        "@types/react": "^18.2.0",
+        "@types/react-dom": "^18.2.0",
+        "@vitejs/plugin-react": "^4.0.0",
+        "typescript": "^5.2.0",
+        "vite": "^4.4.0"
+      },
+      "peerDependencies": {
+        "react": ">=17.0.0",
+        "react-dom": ">=17.0.0"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
+      "integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.27.1",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.28.4.tgz",
+      "integrity": "sha512-YsmSKC29MJwf0gF8Rjjrg5LQCmyh+j/nD8/eP7f+BeoQTKYqs9RoWbjGOdy0+1Ekr68RJZMUOPVQaQisnIo4Rw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.4.tgz",
+      "integrity": "sha512-2BCOP7TN8M+gVDj7/ht3hsaO/B/n5oDbiAyyvnRlNOs+u1o+JWNYTQrmpuNp1/Wq2gcFrI01JAW+paEKDMx/CA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.27.1",
+        "@babel/generator": "^7.28.3",
+        "@babel/helper-compilation-targets": "^7.27.2",
+        "@babel/helper-module-transforms": "^7.28.3",
+        "@babel/helpers": "^7.28.4",
+        "@babel/parser": "^7.28.4",
+        "@babel/template": "^7.27.2",
+        "@babel/traverse": "^7.28.4",
+        "@babel/types": "^7.28.4",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.28.3",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.28.3.tgz",
+      "integrity": "sha512-3lSpxGgvnmZznmBkCRnVREPUFJv2wrv9iAoFDvADJc0ypmdOxdUtcLeBgBJ6zE0PMeTKnxeQzyk0xTBq4Ep7zw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.28.3",
+        "@babel/types": "^7.28.2",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.27.2",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.27.2.tgz",
+      "integrity": "sha512-2+1thGUUWWjLTYTHZWK1n8Yga0ijBz1XAhUXcKy81rd5g6yh7hGqMp45v7cadSbEHc9G3OTv45SyneRN3ps4DQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.27.2",
+        "@babel/helper-validator-option": "^7.27.1",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
+      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.27.1.tgz",
+      "integrity": "sha512-0gSFWUPNXNopqtIPQvlD5WgXYI5GY2kP2cCvoT8kczjbfcfuIljTbcWrulD1CIPIX2gt1wghbDy08yE1p+/r3w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.27.1",
+        "@babel/types": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.28.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.3.tgz",
+      "integrity": "sha512-gytXUbs8k2sXS9PnQptz5o0QnpLL51SwASIORY6XaBKF88nsOT0Zw9szLqlSGQDP/4TljBAD5y98p2U1fqkdsw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.27.1",
+        "@babel/traverse": "^7.28.3"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-plugin-utils": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.27.1.tgz",
+      "integrity": "sha512-1gn1Up5YXka3YYAHGKpbideQ5Yjf1tDa9qYcgysz+cNCXukyLl6DjPXhD3VRwSb8c0J9tA4b2+rHEZtc6R0tlw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz",
+      "integrity": "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
+      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.4.tgz",
+      "integrity": "sha512-HFN59MmQXGHVyYadKLVumYsA9dBFun/ldYxipEjzA4196jpLZd8UjEEBLkbEkvfYreDqJhZxYAWFPtrfhNpj4w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.27.2",
+        "@babel/types": "^7.28.4"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.4.tgz",
+      "integrity": "sha512-yZbBqeM6TkpP9du/I2pUZnJsRMGGvOuIrhjzC1AwHwW+6he4mni6Bp/m8ijn0iOuZuPI2BfkCoSRunpyjnrQKg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.28.4"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-self": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.27.1.tgz",
+      "integrity": "sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-source": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.27.1.tgz",
+      "integrity": "sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.27.2",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.2.tgz",
+      "integrity": "sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.27.1",
+        "@babel/parser": "^7.27.2",
+        "@babel/types": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.28.4.tgz",
+      "integrity": "sha512-YEzuboP2qvQavAcjgQNVgsvHIDv6ZpwXvcvjmyySP2DIMuByS/6ioU5G9pYrWHM6T2YDfc7xga9iNzYOs12CFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.27.1",
+        "@babel/generator": "^7.28.3",
+        "@babel/helper-globals": "^7.28.0",
+        "@babel/parser": "^7.28.4",
+        "@babel/template": "^7.27.2",
+        "@babel/types": "^7.28.4",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.4.tgz",
+      "integrity": "sha512-bkFqkLhh3pMBUQQkpVgWDWq/lqzc2678eUyDlTBhRqhCHFguYYGM0Efga7tYk4TogG/3x0EEl66/OQ+WGbWB/Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.18.20.tgz",
+      "integrity": "sha512-fyi7TDI/ijKKNZTUJAQqiG5T7YjJXgnzkURqmGj13C6dCqckZBLdl4h7bkhHt/t0WP+zO9/zwroDvANaOqO5Sw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.18.20.tgz",
+      "integrity": "sha512-Nz4rJcchGDtENV0eMKUNa6L12zz2zBDXuhj/Vjh18zGqB44Bi7MBMSXjgunJgjRhCmKOjnPuZp4Mb6OKqtMHLQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.18.20.tgz",
+      "integrity": "sha512-8GDdlePJA8D6zlZYJV/jnrRAi6rOiNaCC/JclcXpB+KIuvfBN4owLtgzY2bsxnx666XjJx2kDPUmnTtR8qKQUg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.18.20.tgz",
+      "integrity": "sha512-bxRHW5kHU38zS2lPTPOyuyTm+S+eobPUnTNkdJEfAddYgEcll4xkT8DB9d2008DtTbl7uJag2HuE5NZAZgnNEA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.18.20.tgz",
+      "integrity": "sha512-pc5gxlMDxzm513qPGbCbDukOdsGtKhfxD1zJKXjCCcU7ju50O7MeAZ8c4krSJcOIJGFR+qx21yMMVYwiQvyTyQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.18.20.tgz",
+      "integrity": "sha512-yqDQHy4QHevpMAaxhhIwYPMv1NECwOvIpGCZkECn8w2WFHXjEwrBn3CeNIYsibZ/iZEUemj++M26W3cNR5h+Tw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.18.20.tgz",
+      "integrity": "sha512-tgWRPPuQsd3RmBZwarGVHZQvtzfEBOreNuxEMKFcd5DaDn2PbBxfwLcj4+aenoh7ctXcbXmOQIn8HI6mCSw5MQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.18.20.tgz",
+      "integrity": "sha512-/5bHkMWnq1EgKr1V+Ybz3s1hWXok7mDFUMQ4cG10AfW3wL02PSZi5kFpYKrptDsgb2WAJIvRcDm+qIvXf/apvg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.18.20.tgz",
+      "integrity": "sha512-2YbscF+UL7SQAVIpnWvYwM+3LskyDmPhe31pE7/aoTMFKKzIc9lLbyGUpmmb8a8AixOL61sQ/mFh3jEjHYFvdA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.18.20.tgz",
+      "integrity": "sha512-P4etWwq6IsReT0E1KHU40bOnzMHoH73aXp96Fs8TIT6z9Hu8G6+0SHSw9i2isWrD2nbx2qo5yUqACgdfVGx7TA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.18.20.tgz",
+      "integrity": "sha512-nXW8nqBTrOpDLPgPY9uV+/1DjxoQ7DoB2N8eocyq8I9XuqJ7BiAMDMf9n1xZM9TgW0J8zrquIb/A7s3BJv7rjg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.18.20.tgz",
+      "integrity": "sha512-d5NeaXZcHp8PzYy5VnXV3VSd2D328Zb+9dEq5HE6bw6+N86JVPExrA6O68OPwobntbNJ0pzCpUFZTo3w0GyetQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.18.20.tgz",
+      "integrity": "sha512-WHPyeScRNcmANnLQkq6AfyXRFr5D6N2sKgkFo2FqguP44Nw2eyDlbTdZwd9GYk98DZG9QItIiTlFLHJHjxP3FA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.18.20.tgz",
+      "integrity": "sha512-WSxo6h5ecI5XH34KC7w5veNnKkju3zBRLEQNY7mv5mtBmrP/MjNBCAlsM2u5hDBlS3NGcTQpoBvRzqBcRtpq1A==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.18.20.tgz",
+      "integrity": "sha512-+8231GMs3mAEth6Ja1iK0a1sQ3ohfcpzpRLH8uuc5/KVDFneH6jtAJLFGafpzpMRO6DzJ6AvXKze9LfFMrIHVQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.18.20.tgz",
+      "integrity": "sha512-UYqiqemphJcNsFEskc73jQ7B9jgwjWrSayxawS6UVFZGWrAAtkzjxSqnoclCXxWtfwLdzU+vTpcNYhpn43uP1w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.18.20.tgz",
+      "integrity": "sha512-iO1c++VP6xUBUmltHZoMtCUdPlnPGdBom6IrO4gyKPFFVBKioIImVooR5I83nTew5UOYrk3gIJhbZh8X44y06A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.18.20.tgz",
+      "integrity": "sha512-e5e4YSsuQfX4cxcygw/UCPIEP6wbIL+se3sxPdCiMbFLBWu0eiZOJ7WoD+ptCLrmjZBK1Wk7I6D/I3NglUGOxg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.18.20.tgz",
+      "integrity": "sha512-kDbFRFp0YpTQVVrqUd5FTYmWo45zGaXe0X8E1G/LKFC0v8x0vWrhOWSLITcCn63lmZIxfOMXtCfti/RxN/0wnQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.18.20.tgz",
+      "integrity": "sha512-ddYFR6ItYgoaq4v4JmQQaAI5s7npztfV4Ag6NrhiaW0RrnOXqBkgwZLofVTlq1daVTQNhtI5oieTvkRPfZrePg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.18.20.tgz",
+      "integrity": "sha512-Wv7QBi3ID/rROT08SABTS7eV4hX26sVduqDOTe1MvGMjNd3EjOz4b7zeexIR62GTIEKrfJXKL9LFxTYgkyeu7g==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.18.20.tgz",
+      "integrity": "sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@jsplumb/community": {
+      "version": "4.0.0-RC47",
+      "resolved": "https://registry.npmjs.org/@jsplumb/community/-/community-4.0.0-RC47.tgz",
+      "integrity": "sha512-VASXynkaJ3W5/nL7L9HkwA4E50aBpEtUor+rLc2+rBoWcyfl3rdqHbnqTjNrKNwqkEvn2jeQje8mo/P6UZ0yqA==",
+      "license": "(MIT OR GPL-2.0)"
+    },
+    "node_modules/@jsplumb/core": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@jsplumb/core/-/core-4.0.0.tgz",
+      "integrity": "sha512-8S8KTWzrW7VomfzFQ86DIqWiaxbkdjoQljnW7n1VpluoqDfaDeIc5hAvAlYVc4CKJCZKrbTwls+GOvO5CFBpcQ==",
+      "license": "(MIT OR GPL-2.0)"
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-beta.27",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
+      "integrity": "sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/babel__core": {
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+      "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7",
+        "@types/babel__generator": "*",
+        "@types/babel__template": "*",
+        "@types/babel__traverse": "*"
+      }
+    },
+    "node_modules/@types/babel__generator": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
+      "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__template": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+      "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__traverse": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+      "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.28.2"
+      }
+    },
+    "node_modules/@types/prop-types": {
+      "version": "15.7.15",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
+      "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/react": {
+      "version": "18.3.24",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.24.tgz",
+      "integrity": "sha512-0dLEBsA1kI3OezMBF8nSsb7Nk19ZnsyE1LLhB8r27KbgU5H4pvuqZLdtE+aUkJVoXgTVuA+iLIwmZ0TuK4tx6A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/prop-types": "*",
+        "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "18.3.7",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
+      "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^18.0.0"
+      }
+    },
+    "node_modules/@vitejs/plugin-react": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.7.0.tgz",
+      "integrity": "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.28.0",
+        "@babel/plugin-transform-react-jsx-self": "^7.27.1",
+        "@babel/plugin-transform-react-jsx-source": "^7.27.1",
+        "@rolldown/pluginutils": "1.0.0-beta.27",
+        "@types/babel__core": "^7.20.5",
+        "react-refresh": "^0.17.0"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+      }
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.8.4",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.8.4.tgz",
+      "integrity": "sha512-L+YvJwGAgwJBV1p6ffpSTa2KRc69EeeYGYjRVWKs0GKrK+LON0GC0gV+rKSNtALEDvMDqkvCFq9r1r94/Gjwxw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.js"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.26.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.26.2.tgz",
+      "integrity": "sha512-ECFzp6uFOSB+dcZ5BK/IBaGWssbSYBHvuMeMt3MMFyhI0Z8SqGgEkBLARgpRH3hutIgPVsALcMwbDrJqPxQ65A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "baseline-browser-mapping": "^2.8.3",
+        "caniuse-lite": "^1.0.30001741",
+        "electron-to-chromium": "^1.5.218",
+        "node-releases": "^2.0.21",
+        "update-browserslist-db": "^1.1.3"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001743",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001743.tgz",
+      "integrity": "sha512-e6Ojr7RV14Un7dz6ASD0aZDmQPT/A+eZU+nuTNfjqmRrmkmQlnTNWH0SKmqagx9PeW87UVqapSurtAXifmtdmw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/csstype": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.218",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.218.tgz",
+      "integrity": "sha512-uwwdN0TUHs8u6iRgN8vKeWZMRll4gBkz+QMqdS7DDe49uiK68/UX92lFb61oiFPrpYZNeZIqa4bA7O6Aiasnzg==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/esbuild": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.18.20.tgz",
+      "integrity": "sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/android-arm": "0.18.20",
+        "@esbuild/android-arm64": "0.18.20",
+        "@esbuild/android-x64": "0.18.20",
+        "@esbuild/darwin-arm64": "0.18.20",
+        "@esbuild/darwin-x64": "0.18.20",
+        "@esbuild/freebsd-arm64": "0.18.20",
+        "@esbuild/freebsd-x64": "0.18.20",
+        "@esbuild/linux-arm": "0.18.20",
+        "@esbuild/linux-arm64": "0.18.20",
+        "@esbuild/linux-ia32": "0.18.20",
+        "@esbuild/linux-loong64": "0.18.20",
+        "@esbuild/linux-mips64el": "0.18.20",
+        "@esbuild/linux-ppc64": "0.18.20",
+        "@esbuild/linux-riscv64": "0.18.20",
+        "@esbuild/linux-s390x": "0.18.20",
+        "@esbuild/linux-x64": "0.18.20",
+        "@esbuild/netbsd-x64": "0.18.20",
+        "@esbuild/openbsd-x64": "0.18.20",
+        "@esbuild/sunos-x64": "0.18.20",
+        "@esbuild/win32-arm64": "0.18.20",
+        "@esbuild/win32-ia32": "0.18.20",
+        "@esbuild/win32-x64": "0.18.20"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.21",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.21.tgz",
+      "integrity": "sha512-5b0pgg78U3hwXkCM8Z9b2FJdPZlr9Psr9V2gQPESdGHqbntyFJKFW4r5TeWGFzafGY3hzs1JC62VEQMbl1JFkw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/postcss": {
+      "version": "8.5.6",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
+      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/react": {
+      "version": "19.1.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.1.1.tgz",
+      "integrity": "sha512-w8nqGImo45dmMIfljjMwOGtbmC/mk4CMYhWIicdSflH91J9TyCyczcPFXJzrZ/ZXcgGRFeP6BU0BEJTw6tZdfQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "19.1.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.1.tgz",
+      "integrity": "sha512-Dlq/5LAZgF0Gaz6yiqZCf6VCcZs1ghAJyrsu84Q/GT0gV+mCxbfmKNoGRKBYMJ8IEdGPqu49YWXD02GCknEDkw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "scheduler": "^0.26.0"
+      },
+      "peerDependencies": {
+        "react": "^19.1.1"
+      }
+    },
+    "node_modules/react-refresh": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
+      "integrity": "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "3.29.5",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.29.5.tgz",
+      "integrity": "sha512-GVsDdsbJzzy4S/v3dqWPJ7EfvZJfCHiDqe80IyrF59LYuP+e6U1LJoUqeuqRbwAWoMNoXivMNeNAOf5E22VA1w==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=14.18.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.26.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.26.0.tgz",
+      "integrity": "sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
+      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.3.tgz",
+      "integrity": "sha512-UxhIZQ+QInVdunkDAaiazvvT/+fXL5Osr0JZlJulepYu6Jd7qJtDZjlur0emRlT71EN3ScPoE7gvsuIKKNavKw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/vite": {
+      "version": "4.5.14",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-4.5.14.tgz",
+      "integrity": "sha512-+v57oAaoYNnO3hIu5Z/tJRZjq5aHM2zDve9YZ8HngVHbhk66RStobhb1sqPMIPEleV6cNKYK4eGrAbE9Ulbl2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.18.10",
+        "postcss": "^8.4.27",
+        "rollup": "^3.27.1"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      },
+      "peerDependencies": {
+        "@types/node": ">= 14",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true,
+      "license": "ISC"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "jsplumb-react-wrapper",
+  "version": "0.1.0",
+  "description": "React + TypeScript wrapper around the @jsplumb/community library for interactive node graphs.",
+  "main": "dist/index.cjs.js",
+  "module": "dist/index.es.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc -p tsconfig.build.json && vite build",
+    "dev": "vite"
+  },
+  "keywords": [
+    "jsplumb",
+    "react",
+    "graph",
+    "diagram"
+  ],
+  "author": "",
+  "license": "MIT",
+  "peerDependencies": {
+    "react": ">=17.0.0",
+    "react-dom": ">=17.0.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.0",
+    "@types/react-dom": "^18.2.0",
+    "@vitejs/plugin-react": "^4.0.0",
+    "typescript": "^5.2.0",
+    "vite": "^4.4.0"
+  },
+  "dependencies": {
+    "@jsplumb/community": "^4.0.0-RC47",
+    "@jsplumb/core": "^4.0.0-RC47"
+  }
+}

--- a/src/components/FlowCanvas.tsx
+++ b/src/components/FlowCanvas.tsx
@@ -1,104 +1,14 @@
-import {
-  forwardRef,
-  useCallback,
-  useEffect,
-  useImperativeHandle,
-  useLayoutEffect,
-  useMemo,
-  useRef,
-  useState
-} from 'react';
+import { forwardRef, useCallback, useImperativeHandle, useRef } from 'react';
 import type React from 'react';
-import type { CSSProperties, ReactNode } from 'react';
-import { BrowserJsPlumbInstance, EVENT_DRAG_STOP, newInstance } from '@jsplumb/community';
-import type { DragStopEventParams } from '@jsplumb/community/types/browser-ui/drag-manager';
-import {
-  EVENT_CONNECTION,
-  EVENT_CONNECTION_DETACHED,
-  EVENT_DBL_CLICK,
-  EVENT_MOUSEENTER,
-  EVENT_MOUSEEXIT,
-  EVENT_CLICK,
-  Connection,
-  ConnectionEstablishedParams,
-  ConnectionDetachedParams,
-  Endpoint
-} from '@jsplumb/core';
-import {
-  CanvasSelection,
-  DraftConnection,
-  FlowCanvasHandle,
-  FlowCanvasProps,
-  FlowConnection,
-  FlowNode,
-  NodePort
-} from '../types';
+import type { BrowserJsPlumbInstance } from '@jsplumb/community';
+import GraphNodes from './GraphNodes';
+import useJsPlumbCanvas from '../hooks/useJsPlumbCanvas';
+import useLatest from '../hooks/useLatest';
+import useNodeRegistry from '../hooks/useNodeRegistry';
+import usePanZoom from '../hooks/usePanZoom';
+import useSelectionManager from '../hooks/useSelectionManager';
+import type { FlowCanvasHandle, FlowCanvasProps, FlowNode } from '../types';
 import '../styles/graph.css';
-
-const CONNECTION_ID_PARAM = 'jr-connection-id';
-const CONNECTION_CLASS_PARAM = 'jr-connection-class';
-const CONNECTION_HANDLERS_PARAM = 'jr-connection-handlers';
-const NODE_ID_ATTRIBUTE = 'data-node-id';
-const DEFAULT_PORT_ID = 'default';
-
-const flattenConnections = (instance: BrowserJsPlumbInstance): Connection[] => {
-  const jp = instance as unknown as { getConnections?: (options?: unknown, flat?: boolean) => Connection[] };
-  const connections = jp.getConnections ? jp.getConnections({}, true) : [];
-  return Array.isArray(connections) ? connections : [];
-};
-
-const getEndpointUuid = (nodeId: string, portId?: string) => `${nodeId}:${portId ?? DEFAULT_PORT_ID}`;
-
-const isSameUuid = (conn: Connection, source: string, target: string) => {
-  const [currentSource, currentTarget] = conn.getUuids();
-  return currentSource === source && currentTarget === target;
-};
-
-const uniqueList = (values: string[]) => Array.from(new Set(values));
-
-const toDraftConnection = (info: ConnectionEstablishedParams<Element>): DraftConnection | null => {
-  const sourcePortId = info.sourceEndpoint?.portId ?? undefined;
-  const targetPortId = info.targetEndpoint?.portId ?? undefined;
-  const sourceElement = info.sourceEndpoint?.element as HTMLElement | undefined;
-  const targetElement = info.targetEndpoint?.element as HTMLElement | undefined;
-  const sourceNode = sourceElement?.closest('.jr-node') as HTMLElement | null;
-  const targetNode = targetElement?.closest('.jr-node') as HTMLElement | null;
-  const sourceNodeId = sourceNode?.getAttribute(NODE_ID_ATTRIBUTE);
-  const targetNodeId = targetNode?.getAttribute(NODE_ID_ATTRIBUTE);
-  if (!sourceNodeId || !targetNodeId) {
-    return null;
-  }
-  return {
-    source: { nodeId: sourceNodeId, portId: sourcePortId === DEFAULT_PORT_ID ? undefined : sourcePortId },
-    target: { nodeId: targetNodeId, portId: targetPortId === DEFAULT_PORT_ID ? undefined : targetPortId }
-  };
-};
-
-const getConnectionParameter = (connection: Connection, key: string) => {
-  const withMethods = connection as unknown as {
-    getParameter?: (name: string) => unknown;
-    parameters?: Record<string, unknown>;
-  };
-  if (withMethods.getParameter) {
-    return withMethods.getParameter(key);
-  }
-  return withMethods.parameters?.[key];
-};
-
-const setConnectionParameter = (connection: Connection, key: string, value: unknown) => {
-  const withMethods = connection as unknown as {
-    setParameter?: (name: string, value: unknown) => void;
-    parameters?: Record<string, unknown>;
-  };
-  if (withMethods.setParameter) {
-    withMethods.setParameter(key, value);
-  } else {
-    if (!withMethods.parameters) {
-      withMethods.parameters = {};
-    }
-    withMethods.parameters[key] = value;
-  }
-};
 
 const FlowCanvas = forwardRef<FlowCanvasHandle, FlowCanvasProps>((props, ref) => {
   const {
@@ -127,636 +37,112 @@ const FlowCanvas = forwardRef<FlowCanvasHandle, FlowCanvasProps>((props, ref) =>
     onCanvasClick
   } = props;
 
-  const [internalSelection, setInternalSelection] = useState<CanvasSelection>({ nodes: [], connections: [] });
-  const [zoomState, setZoomState] = useState(zoomProp ?? 1);
-  const [pan, setPan] = useState({ x: 0, y: 0 });
-
   const canvasRef = useRef<HTMLDivElement | null>(null);
   const surfaceRef = useRef<HTMLDivElement | null>(null);
   const graphRef = useRef<HTMLDivElement | null>(null);
   const instanceRef = useRef<BrowserJsPlumbInstance | null>(null);
-  const nodeRefs = useRef<Map<string, HTMLDivElement>>(new Map());
-  const portRefs = useRef<Map<string, Map<string, HTMLElement>>>(new Map());
-  const endpointMapRef = useRef<Map<string, Endpoint>>(new Map());
-  const connectionMapRef = useRef<Map<string, Connection>>(new Map());
-  const syncingRef = useRef(false);
 
-  const panStartRef = useRef<{ x: number; y: number; originX: number; originY: number } | null>(null);
+  const onNodeClickRef = useLatest(onNodeClick);
+  const onNodeDoubleClickRef = useLatest(onNodeDoubleClick);
+  const onNodePositionChangeRef = useLatest(onNodePositionChange);
+  const onLinkClickRef = useLatest(onLinkClick);
+  const onLinkDoubleClickRef = useLatest(onLinkDoubleClick);
+  const onDeleteNodeRef = useLatest(onDeleteNode);
+  const onDeleteLinkRef = useLatest(onDeleteLink);
+  const onLinkCreateRef = useLatest(onLinkCreate);
+  const onLinkDetachedRef = useLatest(onLinkDetached);
+  const onCanvasClickRef = useLatest(onCanvasClick);
 
-  const selection: CanvasSelection = useMemo(
-    () => ({
-      nodes: selectedNodesProp ?? internalSelection.nodes,
-      connections: selectedConnectionsProp ?? internalSelection.connections
-    }),
-    [internalSelection.connections, internalSelection.nodes, selectedConnectionsProp, selectedNodesProp]
-  );
+  const {
+    selection,
+    emitSelectionRef,
+    selectionRef,
+    allowMultiSelectRef,
+    updateNodeSelection,
+    clearSelection
+  } = useSelectionManager({
+    selectedNodes: selectedNodesProp,
+    selectedConnections: selectedConnectionsProp,
+    allowMultiSelect,
+    onSelectionChange
+  });
 
-  const zoomRef = useRef(zoomState);
-  const panRef = useRef(pan);
-  const allowMultiSelectRef = useRef(allowMultiSelect);
-  const selectionRef = useRef(selection);
-  const onNodeClickRef = useRef(onNodeClick);
-  const onNodeDoubleClickRef = useRef(onNodeDoubleClick);
-  const onNodePositionChangeRef = useRef(onNodePositionChange);
-  const onLinkClickRef = useRef(onLinkClick);
-  const onLinkDoubleClickRef = useRef(onLinkDoubleClick);
-  const onDeleteNodeRef = useRef(onDeleteNode);
-  const onDeleteLinkRef = useRef(onDeleteLink);
-  const onLinkCreateRef = useRef(onLinkCreate);
-  const onLinkDetachedRef = useRef(onLinkDetached);
-  const onSelectionChangeRef = useRef(onSelectionChange);
-  const onCanvasClickRef = useRef(onCanvasClick);
+  const { setZoom, zoomIn, zoomOut, resetZoom, zoomRef, setPan, handleWheel, handleCanvasMouseDown } = usePanZoom({
+    canvasRef,
+    surfaceRef,
+    instanceRef,
+    zoom: zoomProp,
+    minZoom,
+    maxZoom,
+    zoomStep
+  });
 
-  useEffect(() => {
-    zoomRef.current = zoomState;
-  }, [zoomState]);
+  const { nodeRefs, portRefs, registerNodeRef, registerPortRef } = useNodeRegistry();
 
-  useEffect(() => {
-    panRef.current = pan;
-    if (surfaceRef.current) {
-      surfaceRef.current.style.transform = `translate(${pan.x}px, ${pan.y}px)`;
-    }
-  }, [pan]);
+  useJsPlumbCanvas({
+    graphRef,
+    nodes,
+    connections,
+    readonly,
+    nodeRefs,
+    portRefs,
+    instanceRef,
+    selection,
+    selectionRef,
+    allowMultiSelectRef,
+    emitSelectionRef,
+    onLinkClickRef,
+    onLinkDoubleClickRef,
+    onDeleteLinkRef,
+    onLinkCreateRef,
+    onLinkDetachedRef,
+    onNodePositionChangeRef
+  });
 
-  useEffect(() => {
-    selectionRef.current = selection;
-  }, [selection]);
-
-  useEffect(() => {
-    allowMultiSelectRef.current = allowMultiSelect;
-  }, [allowMultiSelect]);
-
-  useEffect(() => {
-    onNodeClickRef.current = onNodeClick;
-  }, [onNodeClick]);
-  useEffect(() => {
-    onNodeDoubleClickRef.current = onNodeDoubleClick;
-  }, [onNodeDoubleClick]);
-  useEffect(() => {
-    onNodePositionChangeRef.current = onNodePositionChange;
-  }, [onNodePositionChange]);
-  useEffect(() => {
-    onLinkClickRef.current = onLinkClick;
-  }, [onLinkClick]);
-  useEffect(() => {
-    onLinkDoubleClickRef.current = onLinkDoubleClick;
-  }, [onLinkDoubleClick]);
-  useEffect(() => {
-    onDeleteNodeRef.current = onDeleteNode;
-  }, [onDeleteNode]);
-  useEffect(() => {
-    onDeleteLinkRef.current = onDeleteLink;
-  }, [onDeleteLink]);
-  useEffect(() => {
-    onLinkCreateRef.current = onLinkCreate;
-  }, [onLinkCreate]);
-  useEffect(() => {
-    onLinkDetachedRef.current = onLinkDetached;
-  }, [onLinkDetached]);
-  useEffect(() => {
-    onSelectionChangeRef.current = onSelectionChange;
-  }, [onSelectionChange]);
-  useEffect(() => {
-    onCanvasClickRef.current = onCanvasClick;
-  }, [onCanvasClick]);
-
-  const clampZoom = useCallback(
-    (value: number) => Math.min(maxZoom, Math.max(minZoom, value)),
-    [maxZoom, minZoom]
-  );
-
-  const setZoomInternal = useCallback(
-    (value: number) => {
-      const clamped = clampZoom(value);
-      setZoomState((current) => {
-        if (current === clamped) {
-          return current;
-        }
-        return clamped;
-      });
-      zoomRef.current = clamped;
-      if (instanceRef.current) {
-        const jp = instanceRef.current as unknown as { setZoom?: (zoom: number, repaint?: boolean) => void };
-        jp.setZoom?.(clamped, true);
-      }
-      return clamped;
+  const handleNodeClick = useCallback(
+    (node: FlowNode, event: React.MouseEvent<HTMLDivElement>) => {
+      updateNodeSelection(node.id, event);
+      onNodeClickRef.current?.(node, event.nativeEvent);
     },
-    [clampZoom]
+    [onNodeClickRef, updateNodeSelection]
   );
 
-  useEffect(() => {
-    if (typeof zoomProp === 'number') {
-      setZoomInternal(zoomProp);
-    }
-  }, [setZoomInternal, zoomProp]);
-
-  const emitSelection = useCallback(
-    (nextNodes: string[], nextConnections: string[]) => {
-      setInternalSelection((previous) => ({
-        nodes: selectedNodesProp === undefined ? nextNodes : previous.nodes,
-        connections: selectedConnectionsProp === undefined ? nextConnections : previous.connections
-      }));
-      const finalSelection: CanvasSelection = {
-        nodes: selectedNodesProp ?? nextNodes,
-        connections: selectedConnectionsProp ?? nextConnections
-      };
-      onSelectionChangeRef.current?.(finalSelection);
+  const handleNodeDoubleClick = useCallback(
+    (node: FlowNode, event: React.MouseEvent<HTMLDivElement>) => {
+      event.stopPropagation();
+      onNodeDoubleClickRef.current?.(node, event.nativeEvent);
     },
-    [selectedConnectionsProp, selectedNodesProp]
+    [onNodeDoubleClickRef]
   );
 
-  const handlePanMove = useCallback((event: MouseEvent) => {
-    const start = panStartRef.current;
-    if (!start) {
-      return;
-    }
-    const dx = event.clientX - start.x;
-    const dy = event.clientY - start.y;
-    setPan({ x: start.originX + dx, y: start.originY + dy });
-  }, []);
+  const handleDeleteNode = useCallback(
+    (node: FlowNode, event: React.MouseEvent<HTMLButtonElement>) => {
+      event.stopPropagation();
+      onDeleteNodeRef.current?.(node);
+    },
+    [onDeleteNodeRef]
+  );
 
-  const handlePanEnd = useCallback(() => {
-    panStartRef.current = null;
-    window.removeEventListener('mousemove', handlePanMove);
-    window.removeEventListener('mouseup', handlePanEnd);
-  }, [handlePanMove]);
-
-  const handleCanvasMouseDown = useCallback(
+  const handleCanvasClick = useCallback(
     (event: React.MouseEvent<HTMLDivElement>) => {
-      if (event.button !== 0) {
-        return;
-      }
       const target = event.target as HTMLElement;
       if (target.closest('.jr-node') || target.closest('.jr-port') || target.closest('.jr-connection-delete-button')) {
         return;
       }
-      event.preventDefault();
-      panStartRef.current = {
-        x: event.clientX,
-        y: event.clientY,
-        originX: panRef.current.x,
-        originY: panRef.current.y
-      };
-      window.addEventListener('mousemove', handlePanMove);
-      window.addEventListener('mouseup', handlePanEnd);
+      clearSelection();
+      onCanvasClickRef.current?.(event.nativeEvent);
     },
-    [handlePanEnd, handlePanMove]
+    [clearSelection, onCanvasClickRef]
   );
-
-  useEffect(() => () => {
-    window.removeEventListener('mousemove', handlePanMove);
-    window.removeEventListener('mouseup', handlePanEnd);
-  }, [handlePanEnd, handlePanMove]);
-
-  const handleWheel = useCallback(
-    (event: React.WheelEvent<HTMLDivElement>) => {
-      if (!canvasRef.current) {
-        return;
-      }
-      const zoomModifier = event.ctrlKey || event.metaKey;
-      if (!zoomModifier) {
-        return;
-      }
-      event.preventDefault();
-      const canvasRect = canvasRef.current.getBoundingClientRect();
-      const pointerX = event.clientX - canvasRect.left;
-      const pointerY = event.clientY - canvasRect.top;
-      const graphX = (pointerX - panRef.current.x) / zoomRef.current;
-      const graphY = (pointerY - panRef.current.y) / zoomRef.current;
-      const direction = event.deltaY > 0 ? -1 : 1;
-      const nextZoom = setZoomInternal(zoomRef.current + direction * zoomStep);
-      const nextPanX = pointerX - graphX * nextZoom;
-      const nextPanY = pointerY - graphY * nextZoom;
-      setPan({ x: nextPanX, y: nextPanY });
-    },
-    [setZoomInternal, zoomStep]
-  );
-
-  const updateNodeSelection = useCallback(
-    (nodeId: string, event: React.MouseEvent<HTMLDivElement>) => {
-      event.stopPropagation();
-      const multi = allowMultiSelectRef.current && (event.metaKey || event.ctrlKey || event.shiftKey);
-      const currentNodes = new Set(selectionRef.current.nodes);
-      let nextNodes: string[];
-      if (multi) {
-        if (currentNodes.has(nodeId)) {
-          currentNodes.delete(nodeId);
-        } else {
-          currentNodes.add(nodeId);
-        }
-        nextNodes = Array.from(currentNodes);
-      } else {
-        nextNodes = [nodeId];
-      }
-      const nextConnections = multi ? selectionRef.current.connections : [];
-      emitSelection(uniqueList(nextNodes), uniqueList(nextConnections));
-    },
-    [emitSelection]
-  );
-
-  const setSelectionRef = useRef(emitSelection);
-  useEffect(() => {
-    setSelectionRef.current = emitSelection;
-  }, [emitSelection]);
-
-  const attachConnectionHandlers = useCallback(
-    (connection: Connection, data: FlowConnection) => {
-      if (getConnectionParameter(connection, CONNECTION_HANDLERS_PARAM)) {
-        return;
-      }
-      setConnectionParameter(connection, CONNECTION_HANDLERS_PARAM, true);
-      connection.bind(EVENT_CLICK, (conn: Connection, originalEvent?: MouseEvent) => {
-        if (!originalEvent) {
-          return;
-        }
-        const multi = allowMultiSelectRef.current && (originalEvent.metaKey || originalEvent.ctrlKey || originalEvent.shiftKey);
-        const currentConnections = new Set(selectionRef.current.connections);
-        if (multi) {
-          if (currentConnections.has(data.id)) {
-            currentConnections.delete(data.id);
-          } else {
-            currentConnections.add(data.id);
-          }
-        } else {
-          currentConnections.clear();
-          currentConnections.add(data.id);
-        }
-        const nextConnections = Array.from(currentConnections);
-        const nextNodes = multi ? selectionRef.current.nodes : [];
-        setSelectionRef.current?.(uniqueList(nextNodes), uniqueList(nextConnections));
-        onLinkClickRef.current?.(data, originalEvent);
-      });
-
-      connection.bind(EVENT_DBL_CLICK, (_conn: Connection, originalEvent?: MouseEvent) => {
-        if (!originalEvent) {
-          return;
-        }
-        onLinkDoubleClickRef.current?.(data, originalEvent);
-      });
-
-      connection.bind(EVENT_MOUSEENTER, () => {
-        connection.addClass('jr-hover');
-      });
-      connection.bind(EVENT_MOUSEEXIT, () => {
-        connection.removeClass('jr-hover');
-      });
-    },
-    []
-  );
-
-  const ensureDeleteOverlay = useCallback(
-    (connection: Connection, data: FlowConnection) => {
-      const overlayId = `delete-${data.id}`;
-      if (!connection.getOverlay(overlayId)) {
-        connection.addOverlay([
-          'Custom',
-          {
-            id: overlayId,
-            location: 0.5,
-            cssClass: 'jr-connection-delete',
-            create: () => {
-              const button = document.createElement('button');
-              button.type = 'button';
-              button.className = 'jr-connection-delete-button';
-              button.innerHTML = '&times;';
-              button.addEventListener('click', (event) => {
-                event.preventDefault();
-                event.stopPropagation();
-                const connectionData = connectionMapRef.current.get(data.id);
-                if (connectionData) {
-                  onDeleteLinkRef.current?.(data);
-                }
-              });
-              return button;
-            }
-          }
-        ] as any);
-      }
-    },
-    []
-  );
-
-  const updateConnectionMetadata = useCallback(
-    (connection: Connection, data: FlowConnection) => {
-      setConnectionParameter(connection, CONNECTION_ID_PARAM, data.id);
-      const previousClass = getConnectionParameter(connection, CONNECTION_CLASS_PARAM) as string | undefined;
-      if (previousClass && previousClass !== data.className) {
-        connection.removeClass(previousClass);
-      }
-      if (data.className) {
-        connection.addClass(data.className);
-      }
-      setConnectionParameter(connection, CONNECTION_CLASS_PARAM, data.className ?? '');
-      connection.setDetachable(data.editable !== false);
-      connection.addClass('jr-connection');
-      connection.removeClass('jr-selected');
-      if (selection.connections.includes(data.id)) {
-        connection.addClass('jr-selected');
-      }
-      connection.setLabel(data.label ?? '');
-    },
-    [selection.connections]
-  );
-
-  useEffect(() => {
-    if (!graphRef.current) {
-      return;
-    }
-    const instance = newInstance({
-      container: graphRef.current,
-      elementsDraggable: !readonly,
-      dragOptions: { cursor: 'move' }
-    });
-    instanceRef.current = instance;
-    const jp = instance as unknown as {
-      bind?: (event: string, handler: (...args: any[]) => void) => void;
-      deleteConnection?: (connection: Connection, params?: any) => void;
-    };
-
-    const dragStop = (params: DragStopEventParams) => {
-      const element = params.el as HTMLElement;
-      if (!element) {
-        return;
-      }
-      const nodeId = element.getAttribute(NODE_ID_ATTRIBUTE);
-      if (!nodeId) {
-        return;
-      }
-      const [x, y] = params.finalPos;
-      onNodePositionChangeRef.current?.(nodeId, { x, y });
-    };
-
-    jp.bind?.(EVENT_DRAG_STOP, dragStop);
-
-    jp.bind?.(EVENT_CONNECTION, (info: ConnectionEstablishedParams<Element>, originalEvent?: MouseEvent) => {
-      if (syncingRef.current || !originalEvent) {
-        return;
-      }
-      const draft = toDraftConnection(info);
-      if (!draft) {
-        return;
-      }
-      const result = onLinkCreateRef.current?.(draft);
-      if (result === false) {
-        jp.deleteConnection?.(info.connection, { fireEvent: false });
-      }
-    });
-
-    jp.bind?.(EVENT_CONNECTION_DETACHED, (info: ConnectionDetachedParams<Element>) => {
-      if (syncingRef.current) {
-        return;
-      }
-      const draft = toDraftConnection(info);
-      if (!draft) {
-        return;
-      }
-      onLinkDetachedRef.current?.(draft);
-    });
-
-    return () => {
-      instance.destroy();
-      instanceRef.current = null;
-      endpointMapRef.current.clear();
-      connectionMapRef.current.clear();
-    };
-  }, [readonly]);
-
-  useEffect(() => {
-    const instance = instanceRef.current;
-    if (!instance) {
-      return;
-    }
-    const jp = instance as unknown as {
-      elementsDraggable?: boolean;
-      setDraggable?: (el: Element, draggable: boolean) => void;
-    };
-    jp.elementsDraggable = !readonly;
-    nodes.forEach((node) => {
-      const element = nodeRefs.current.get(node.id);
-      if (element) {
-        jp.setDraggable?.(element, !(readonly || node.disableDrag));
-      }
-    });
-  }, [nodes, readonly]);
-
-  useLayoutEffect(() => {
-    const instance = instanceRef.current;
-    if (!instance || !graphRef.current) {
-      return;
-    }
-    const jp = instance as unknown as {
-      batch?: (fn: () => void) => void;
-      getManagedElements?: () => Record<string, { el: Element }>;
-      unmanage?: (el: Element, removeElement?: boolean) => void;
-      setDraggable?: (el: Element, draggable: boolean) => void;
-      revalidate?: (el: Element) => void;
-      manage?: (el: Element, internalId?: string, recalc?: boolean) => void;
-    };
-    syncingRef.current = true;
-    try {
-      jp.batch?.(() => {
-        const managed = jp.getManagedElements ? jp.getManagedElements() : {};
-        const validNodeIds = new Set(nodes.map((node) => node.id));
-        Object.values(managed).forEach((entry) => {
-          const element = (entry as { el?: Element }).el as HTMLElement | undefined;
-          const nodeId = element?.getAttribute(NODE_ID_ATTRIBUTE);
-          if (nodeId && !validNodeIds.has(nodeId)) {
-            if (element) {
-              jp.unmanage?.(element, false);
-            }
-          }
-        });
-
-        nodes.forEach((node) => {
-          const element = nodeRefs.current.get(node.id);
-          if (!element) {
-            return;
-          }
-          element.setAttribute(NODE_ID_ATTRIBUTE, node.id);
-          element.style.left = `${node.position.x}px`;
-          element.style.top = `${node.position.y}px`;
-          jp.manage?.(element, node.id, true);
-          jp.setDraggable?.(element, !(readonly || node.disableDrag));
-          jp.revalidate?.(element);
-        });
-      });
-    } finally {
-      syncingRef.current = false;
-    }
-  }, [nodes, readonly]);
-
-  const synchronizeEndpoints = useCallback(() => {
-    const instance = instanceRef.current;
-    if (!instance) {
-      return;
-    }
-    const jp = instance as unknown as {
-      addEndpoint?: (el: Element, options: Record<string, unknown>) => Endpoint;
-      deleteEndpoint?: (endpoint: Endpoint) => void;
-    };
-    const nextEndpoints = new Map<string, Endpoint>();
-    nodes.forEach((node) => {
-      const element = nodeRefs.current.get(node.id);
-      if (!element) {
-        return;
-      }
-      const ports = node.ports && node.ports.length > 0 ? node.ports : ([{ id: DEFAULT_PORT_ID }] as NodePort[]);
-      ports.forEach((port) => {
-        const uuid = getEndpointUuid(node.id, port.id);
-        const portMap = portRefs.current.get(node.id);
-        const portElement = portMap?.get(port.id) ?? element;
-        if (!portElement) {
-          return;
-        }
-        let endpoint = endpointMapRef.current.get(uuid);
-        if (!endpoint) {
-          endpoint = jp.addEndpoint?.(portElement, {
-            uuid,
-            anchor: port.anchor ?? 'AutoDefault',
-            portId: port.id,
-            isSource: port.mode !== 'target',
-            isTarget: port.mode !== 'source',
-            maxConnections: -1
-          }) as Endpoint;
-        } else {
-          endpoint.setAnchor(port.anchor ?? 'AutoDefault');
-          endpoint.isSource = port.mode !== 'target';
-          endpoint.isTarget = port.mode !== 'source';
-        }
-        nextEndpoints.set(uuid, endpoint);
-      });
-    });
-
-    endpointMapRef.current.forEach((endpoint, key) => {
-      if (!nextEndpoints.has(key)) {
-        jp.deleteEndpoint?.(endpoint);
-      }
-    });
-
-    endpointMapRef.current = nextEndpoints;
-  }, [nodes]);
-
-  useLayoutEffect(() => {
-    synchronizeEndpoints();
-  }, [synchronizeEndpoints]);
-
-  useLayoutEffect(() => {
-    const instance = instanceRef.current;
-    if (!instance) {
-      return;
-    }
-    const jp = instance as unknown as {
-      batch?: (fn: () => void) => void;
-      deleteConnection?: (connection: Connection, params?: any) => void;
-      connect?: (params: Record<string, unknown>) => Connection | undefined;
-    };
-    syncingRef.current = true;
-    try {
-      jp.batch?.(() => {
-        const existing = new Map<string, Connection>();
-        const byUuid = new Map<string, Connection>();
-        flattenConnections(instance).forEach((connection) => {
-          const identifier = getConnectionParameter(connection, CONNECTION_ID_PARAM) as string | undefined;
-          if (identifier) {
-            existing.set(identifier, connection);
-          }
-          const [sourceUuid, targetUuid] = connection.getUuids();
-          byUuid.set(`${sourceUuid}|${targetUuid}`, connection);
-        });
-
-        connections.forEach((data) => {
-          const sourceUuid = getEndpointUuid(data.source.nodeId, data.source.portId);
-          const targetUuid = getEndpointUuid(data.target.nodeId, data.target.portId);
-          const sourceEndpoint = endpointMapRef.current.get(sourceUuid);
-          const targetEndpoint = endpointMapRef.current.get(targetUuid);
-          if (!sourceEndpoint || !targetEndpoint) {
-            return;
-          }
-          let connection = existing.get(data.id);
-          if (connection && !isSameUuid(connection, sourceUuid, targetUuid)) {
-            jp.deleteConnection?.(connection, { fireEvent: false });
-            connectionMapRef.current.delete(data.id);
-            connection = undefined;
-          }
-
-          if (!connection) {
-            const key = `${sourceUuid}|${targetUuid}`;
-            const reused = byUuid.get(key);
-            if (reused) {
-              connection = reused;
-              byUuid.delete(key);
-            }
-          }
-
-          if (!connection) {
-            const newConnection = jp.connect?.({
-              uuids: [sourceUuid, targetUuid],
-              detachable: data.editable !== false,
-              deleteEndpointsOnDetach: false
-            }) as Connection | undefined;
-            if (!newConnection) {
-              return;
-            }
-            attachConnectionHandlers(newConnection, data);
-            ensureDeleteOverlay(newConnection, data);
-            connection = newConnection;
-          } else {
-            attachConnectionHandlers(connection, data);
-            ensureDeleteOverlay(connection, data);
-          }
-
-          if (connection) {
-            connectionMapRef.current.set(data.id, connection);
-            updateConnectionMetadata(connection, data);
-          }
-          existing.delete(data.id);
-        });
-
-        existing.forEach((connection, id) => {
-          jp.deleteConnection?.(connection, { fireEvent: false });
-          connectionMapRef.current.delete(id);
-        });
-      });
-    } finally {
-      syncingRef.current = false;
-    }
-  }, [attachConnectionHandlers, connections, ensureDeleteOverlay, updateConnectionMetadata]);
-
-  useEffect(() => {
-    connectionMapRef.current.forEach((connection, id) => {
-      if (selection.connections.includes(id)) {
-        connection.addClass('jr-selected');
-      } else {
-        connection.removeClass('jr-selected');
-      }
-    });
-  }, [selection.connections]);
-
-  useEffect(() => {
-    nodes.forEach((node) => {
-      const element = nodeRefs.current.get(node.id);
-      if (!element) {
-        return;
-      }
-      if (selection.nodes.includes(node.id)) {
-        element.classList.add('jr-selected');
-      } else {
-        element.classList.remove('jr-selected');
-      }
-    });
-  }, [nodes, selection.nodes]);
 
   useImperativeHandle(
     ref,
     () => ({
-      zoomIn: () => setZoomInternal(zoomRef.current + zoomStep),
-      zoomOut: () => setZoomInternal(zoomRef.current - zoomStep),
-      resetZoom: () => {
-        setPan({ x: 0, y: 0 });
-        setZoomInternal(1);
-      },
+      zoomIn,
+      zoomOut,
+      resetZoom,
       setZoom: (value: number) => {
-        setZoomInternal(value);
+        setZoom(value);
       },
       getZoom: () => zoomRef.current,
       focusNode: (nodeId: string) => {
@@ -776,58 +162,8 @@ const FlowCanvas = forwardRef<FlowCanvasHandle, FlowCanvasProps>((props, ref) =>
         setPan({ x: nextPanX, y: nextPanY });
       }
     }),
-    [nodes, setZoomInternal, zoomStep]
+    [nodes, nodeRefs, setPan, setZoom, zoomIn, zoomOut, resetZoom, zoomRef]
   );
-
-  const handleNodeClick = useCallback(
-    (node: FlowNode, event: React.MouseEvent<HTMLDivElement>) => {
-      updateNodeSelection(node.id, event);
-      onNodeClickRef.current?.(node, event.nativeEvent);
-    },
-    [updateNodeSelection]
-  );
-
-  const handleNodeDoubleClick = useCallback((node: FlowNode, event: React.MouseEvent<HTMLDivElement>) => {
-    event.stopPropagation();
-    onNodeDoubleClickRef.current?.(node, event.nativeEvent);
-  }, []);
-
-  const handleDeleteNode = useCallback((node: FlowNode, event: React.MouseEvent<HTMLButtonElement>) => {
-    event.stopPropagation();
-    onDeleteNodeRef.current?.(node);
-  }, []);
-
-  const handleCanvasClick = useCallback(
-    (event: React.MouseEvent<HTMLDivElement>) => {
-      const target = event.target as HTMLElement;
-      if (target.closest('.jr-node') || target.closest('.jr-port') || target.closest('.jr-connection-delete-button')) {
-        return;
-      }
-      emitSelection([], []);
-      onCanvasClickRef.current?.(event.nativeEvent);
-    },
-    [emitSelection]
-  );
-
-  const registerNodeRef = useCallback((nodeId: string, element: HTMLDivElement | null) => {
-    if (element) {
-      nodeRefs.current.set(nodeId, element);
-    } else {
-      nodeRefs.current.delete(nodeId);
-    }
-  }, []);
-
-  const registerPortRef = useCallback((nodeId: string, portId: string, element: HTMLElement | null) => {
-    if (!portRefs.current.has(nodeId)) {
-      portRefs.current.set(nodeId, new Map());
-    }
-    const map = portRefs.current.get(nodeId)!;
-    if (element) {
-      map.set(portId, element);
-    } else {
-      map.delete(portId);
-    }
-  }, []);
 
   return (
     <div
@@ -840,40 +176,15 @@ const FlowCanvas = forwardRef<FlowCanvasHandle, FlowCanvasProps>((props, ref) =>
     >
       <div ref={surfaceRef} className="jr-surface">
         <div ref={graphRef} className="jr-graph">
-          {nodes.map((node) => {
-            const ports = node.ports && node.ports.length > 0 ? node.ports : ([{ id: DEFAULT_PORT_ID }] as NodePort[]);
-            const content: ReactNode = typeof node.render === 'function'
-              ? node.render({ node, selected: selection.nodes.includes(node.id), data: node.data })
-              : node.render;
-            return (
-              <div
-                key={node.id}
-                ref={(element) => registerNodeRef(node.id, element)}
-                className={['jr-node', node.className].filter(Boolean).join(' ')}
-                style={node.style as CSSProperties}
-                onClick={(event) => handleNodeClick(node, event)}
-                onDoubleClick={(event) => handleNodeDoubleClick(node, event)}
-              >
-                <div className="jr-node-body">{content}</div>
-                <button type="button" className="jr-node-delete" onClick={(event) => handleDeleteNode(node, event)}>
-                  &times;
-                </button>
-                {ports.map((port) => (
-                  <div
-                    key={port.id}
-                    ref={(element) => registerPortRef(node.id, port.id, element)}
-                    className={['jr-port', port.className, `jr-port-${port.mode ?? 'bidirectional'}`]
-                      .filter(Boolean)
-                      .join(' ')}
-                    data-port-id={port.id}
-                    style={port.style as CSSProperties}
-                  >
-                    {port.label}
-                  </div>
-                ))}
-              </div>
-            );
-          })}
+          <GraphNodes
+            nodes={nodes}
+            selectedNodeIds={selection.nodes}
+            registerNode={registerNodeRef}
+            registerPort={registerPortRef}
+            onNodeClick={handleNodeClick}
+            onNodeDoubleClick={handleNodeDoubleClick}
+            onDeleteNode={handleDeleteNode}
+          />
         </div>
       </div>
     </div>

--- a/src/components/FlowCanvas.tsx
+++ b/src/components/FlowCanvas.tsx
@@ -1,0 +1,885 @@
+import {
+  forwardRef,
+  useCallback,
+  useEffect,
+  useImperativeHandle,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState
+} from 'react';
+import type React from 'react';
+import type { CSSProperties, ReactNode } from 'react';
+import { BrowserJsPlumbInstance, EVENT_DRAG_STOP, newInstance } from '@jsplumb/community';
+import type { DragStopEventParams } from '@jsplumb/community/types/browser-ui/drag-manager';
+import {
+  EVENT_CONNECTION,
+  EVENT_CONNECTION_DETACHED,
+  EVENT_DBL_CLICK,
+  EVENT_MOUSEENTER,
+  EVENT_MOUSEEXIT,
+  EVENT_CLICK,
+  Connection,
+  ConnectionEstablishedParams,
+  ConnectionDetachedParams,
+  Endpoint
+} from '@jsplumb/core';
+import {
+  CanvasSelection,
+  DraftConnection,
+  FlowCanvasHandle,
+  FlowCanvasProps,
+  FlowConnection,
+  FlowNode,
+  NodePort
+} from '../types';
+import '../styles/graph.css';
+
+const CONNECTION_ID_PARAM = 'jr-connection-id';
+const CONNECTION_CLASS_PARAM = 'jr-connection-class';
+const CONNECTION_HANDLERS_PARAM = 'jr-connection-handlers';
+const NODE_ID_ATTRIBUTE = 'data-node-id';
+const DEFAULT_PORT_ID = 'default';
+
+const flattenConnections = (instance: BrowserJsPlumbInstance): Connection[] => {
+  const jp = instance as unknown as { getConnections?: (options?: unknown, flat?: boolean) => Connection[] };
+  const connections = jp.getConnections ? jp.getConnections({}, true) : [];
+  return Array.isArray(connections) ? connections : [];
+};
+
+const getEndpointUuid = (nodeId: string, portId?: string) => `${nodeId}:${portId ?? DEFAULT_PORT_ID}`;
+
+const isSameUuid = (conn: Connection, source: string, target: string) => {
+  const [currentSource, currentTarget] = conn.getUuids();
+  return currentSource === source && currentTarget === target;
+};
+
+const uniqueList = (values: string[]) => Array.from(new Set(values));
+
+const toDraftConnection = (info: ConnectionEstablishedParams<Element>): DraftConnection | null => {
+  const sourcePortId = info.sourceEndpoint?.portId ?? undefined;
+  const targetPortId = info.targetEndpoint?.portId ?? undefined;
+  const sourceElement = info.sourceEndpoint?.element as HTMLElement | undefined;
+  const targetElement = info.targetEndpoint?.element as HTMLElement | undefined;
+  const sourceNode = sourceElement?.closest('.jr-node') as HTMLElement | null;
+  const targetNode = targetElement?.closest('.jr-node') as HTMLElement | null;
+  const sourceNodeId = sourceNode?.getAttribute(NODE_ID_ATTRIBUTE);
+  const targetNodeId = targetNode?.getAttribute(NODE_ID_ATTRIBUTE);
+  if (!sourceNodeId || !targetNodeId) {
+    return null;
+  }
+  return {
+    source: { nodeId: sourceNodeId, portId: sourcePortId === DEFAULT_PORT_ID ? undefined : sourcePortId },
+    target: { nodeId: targetNodeId, portId: targetPortId === DEFAULT_PORT_ID ? undefined : targetPortId }
+  };
+};
+
+const getConnectionParameter = (connection: Connection, key: string) => {
+  const withMethods = connection as unknown as {
+    getParameter?: (name: string) => unknown;
+    parameters?: Record<string, unknown>;
+  };
+  if (withMethods.getParameter) {
+    return withMethods.getParameter(key);
+  }
+  return withMethods.parameters?.[key];
+};
+
+const setConnectionParameter = (connection: Connection, key: string, value: unknown) => {
+  const withMethods = connection as unknown as {
+    setParameter?: (name: string, value: unknown) => void;
+    parameters?: Record<string, unknown>;
+  };
+  if (withMethods.setParameter) {
+    withMethods.setParameter(key, value);
+  } else {
+    if (!withMethods.parameters) {
+      withMethods.parameters = {};
+    }
+    withMethods.parameters[key] = value;
+  }
+};
+
+const FlowCanvas = forwardRef<FlowCanvasHandle, FlowCanvasProps>((props, ref) => {
+  const {
+    nodes,
+    connections,
+    zoom: zoomProp,
+    minZoom = 0.25,
+    maxZoom = 2,
+    zoomStep = 0.1,
+    selectedNodes: selectedNodesProp,
+    selectedConnections: selectedConnectionsProp,
+    allowMultiSelect = true,
+    readonly = false,
+    className,
+    style,
+    onNodeClick,
+    onNodeDoubleClick,
+    onNodePositionChange,
+    onLinkClick,
+    onLinkDoubleClick,
+    onDeleteNode,
+    onDeleteLink,
+    onLinkCreate,
+    onLinkDetached,
+    onSelectionChange,
+    onCanvasClick
+  } = props;
+
+  const [internalSelection, setInternalSelection] = useState<CanvasSelection>({ nodes: [], connections: [] });
+  const [zoomState, setZoomState] = useState(zoomProp ?? 1);
+  const [pan, setPan] = useState({ x: 0, y: 0 });
+
+  const canvasRef = useRef<HTMLDivElement | null>(null);
+  const surfaceRef = useRef<HTMLDivElement | null>(null);
+  const graphRef = useRef<HTMLDivElement | null>(null);
+  const instanceRef = useRef<BrowserJsPlumbInstance | null>(null);
+  const nodeRefs = useRef<Map<string, HTMLDivElement>>(new Map());
+  const portRefs = useRef<Map<string, Map<string, HTMLElement>>>(new Map());
+  const endpointMapRef = useRef<Map<string, Endpoint>>(new Map());
+  const connectionMapRef = useRef<Map<string, Connection>>(new Map());
+  const syncingRef = useRef(false);
+
+  const panStartRef = useRef<{ x: number; y: number; originX: number; originY: number } | null>(null);
+
+  const selection: CanvasSelection = useMemo(
+    () => ({
+      nodes: selectedNodesProp ?? internalSelection.nodes,
+      connections: selectedConnectionsProp ?? internalSelection.connections
+    }),
+    [internalSelection.connections, internalSelection.nodes, selectedConnectionsProp, selectedNodesProp]
+  );
+
+  const zoomRef = useRef(zoomState);
+  const panRef = useRef(pan);
+  const allowMultiSelectRef = useRef(allowMultiSelect);
+  const selectionRef = useRef(selection);
+  const onNodeClickRef = useRef(onNodeClick);
+  const onNodeDoubleClickRef = useRef(onNodeDoubleClick);
+  const onNodePositionChangeRef = useRef(onNodePositionChange);
+  const onLinkClickRef = useRef(onLinkClick);
+  const onLinkDoubleClickRef = useRef(onLinkDoubleClick);
+  const onDeleteNodeRef = useRef(onDeleteNode);
+  const onDeleteLinkRef = useRef(onDeleteLink);
+  const onLinkCreateRef = useRef(onLinkCreate);
+  const onLinkDetachedRef = useRef(onLinkDetached);
+  const onSelectionChangeRef = useRef(onSelectionChange);
+  const onCanvasClickRef = useRef(onCanvasClick);
+
+  useEffect(() => {
+    zoomRef.current = zoomState;
+  }, [zoomState]);
+
+  useEffect(() => {
+    panRef.current = pan;
+    if (surfaceRef.current) {
+      surfaceRef.current.style.transform = `translate(${pan.x}px, ${pan.y}px)`;
+    }
+  }, [pan]);
+
+  useEffect(() => {
+    selectionRef.current = selection;
+  }, [selection]);
+
+  useEffect(() => {
+    allowMultiSelectRef.current = allowMultiSelect;
+  }, [allowMultiSelect]);
+
+  useEffect(() => {
+    onNodeClickRef.current = onNodeClick;
+  }, [onNodeClick]);
+  useEffect(() => {
+    onNodeDoubleClickRef.current = onNodeDoubleClick;
+  }, [onNodeDoubleClick]);
+  useEffect(() => {
+    onNodePositionChangeRef.current = onNodePositionChange;
+  }, [onNodePositionChange]);
+  useEffect(() => {
+    onLinkClickRef.current = onLinkClick;
+  }, [onLinkClick]);
+  useEffect(() => {
+    onLinkDoubleClickRef.current = onLinkDoubleClick;
+  }, [onLinkDoubleClick]);
+  useEffect(() => {
+    onDeleteNodeRef.current = onDeleteNode;
+  }, [onDeleteNode]);
+  useEffect(() => {
+    onDeleteLinkRef.current = onDeleteLink;
+  }, [onDeleteLink]);
+  useEffect(() => {
+    onLinkCreateRef.current = onLinkCreate;
+  }, [onLinkCreate]);
+  useEffect(() => {
+    onLinkDetachedRef.current = onLinkDetached;
+  }, [onLinkDetached]);
+  useEffect(() => {
+    onSelectionChangeRef.current = onSelectionChange;
+  }, [onSelectionChange]);
+  useEffect(() => {
+    onCanvasClickRef.current = onCanvasClick;
+  }, [onCanvasClick]);
+
+  const clampZoom = useCallback(
+    (value: number) => Math.min(maxZoom, Math.max(minZoom, value)),
+    [maxZoom, minZoom]
+  );
+
+  const setZoomInternal = useCallback(
+    (value: number) => {
+      const clamped = clampZoom(value);
+      setZoomState((current) => {
+        if (current === clamped) {
+          return current;
+        }
+        return clamped;
+      });
+      zoomRef.current = clamped;
+      if (instanceRef.current) {
+        const jp = instanceRef.current as unknown as { setZoom?: (zoom: number, repaint?: boolean) => void };
+        jp.setZoom?.(clamped, true);
+      }
+      return clamped;
+    },
+    [clampZoom]
+  );
+
+  useEffect(() => {
+    if (typeof zoomProp === 'number') {
+      setZoomInternal(zoomProp);
+    }
+  }, [setZoomInternal, zoomProp]);
+
+  const emitSelection = useCallback(
+    (nextNodes: string[], nextConnections: string[]) => {
+      setInternalSelection((previous) => ({
+        nodes: selectedNodesProp === undefined ? nextNodes : previous.nodes,
+        connections: selectedConnectionsProp === undefined ? nextConnections : previous.connections
+      }));
+      const finalSelection: CanvasSelection = {
+        nodes: selectedNodesProp ?? nextNodes,
+        connections: selectedConnectionsProp ?? nextConnections
+      };
+      onSelectionChangeRef.current?.(finalSelection);
+    },
+    [selectedConnectionsProp, selectedNodesProp]
+  );
+
+  const handlePanMove = useCallback((event: MouseEvent) => {
+    const start = panStartRef.current;
+    if (!start) {
+      return;
+    }
+    const dx = event.clientX - start.x;
+    const dy = event.clientY - start.y;
+    setPan({ x: start.originX + dx, y: start.originY + dy });
+  }, []);
+
+  const handlePanEnd = useCallback(() => {
+    panStartRef.current = null;
+    window.removeEventListener('mousemove', handlePanMove);
+    window.removeEventListener('mouseup', handlePanEnd);
+  }, [handlePanMove]);
+
+  const handleCanvasMouseDown = useCallback(
+    (event: React.MouseEvent<HTMLDivElement>) => {
+      if (event.button !== 0) {
+        return;
+      }
+      const target = event.target as HTMLElement;
+      if (target.closest('.jr-node') || target.closest('.jr-port') || target.closest('.jr-connection-delete-button')) {
+        return;
+      }
+      event.preventDefault();
+      panStartRef.current = {
+        x: event.clientX,
+        y: event.clientY,
+        originX: panRef.current.x,
+        originY: panRef.current.y
+      };
+      window.addEventListener('mousemove', handlePanMove);
+      window.addEventListener('mouseup', handlePanEnd);
+    },
+    [handlePanEnd, handlePanMove]
+  );
+
+  useEffect(() => () => {
+    window.removeEventListener('mousemove', handlePanMove);
+    window.removeEventListener('mouseup', handlePanEnd);
+  }, [handlePanEnd, handlePanMove]);
+
+  const handleWheel = useCallback(
+    (event: React.WheelEvent<HTMLDivElement>) => {
+      if (!canvasRef.current) {
+        return;
+      }
+      const zoomModifier = event.ctrlKey || event.metaKey;
+      if (!zoomModifier) {
+        return;
+      }
+      event.preventDefault();
+      const canvasRect = canvasRef.current.getBoundingClientRect();
+      const pointerX = event.clientX - canvasRect.left;
+      const pointerY = event.clientY - canvasRect.top;
+      const graphX = (pointerX - panRef.current.x) / zoomRef.current;
+      const graphY = (pointerY - panRef.current.y) / zoomRef.current;
+      const direction = event.deltaY > 0 ? -1 : 1;
+      const nextZoom = setZoomInternal(zoomRef.current + direction * zoomStep);
+      const nextPanX = pointerX - graphX * nextZoom;
+      const nextPanY = pointerY - graphY * nextZoom;
+      setPan({ x: nextPanX, y: nextPanY });
+    },
+    [setZoomInternal, zoomStep]
+  );
+
+  const updateNodeSelection = useCallback(
+    (nodeId: string, event: React.MouseEvent<HTMLDivElement>) => {
+      event.stopPropagation();
+      const multi = allowMultiSelectRef.current && (event.metaKey || event.ctrlKey || event.shiftKey);
+      const currentNodes = new Set(selectionRef.current.nodes);
+      let nextNodes: string[];
+      if (multi) {
+        if (currentNodes.has(nodeId)) {
+          currentNodes.delete(nodeId);
+        } else {
+          currentNodes.add(nodeId);
+        }
+        nextNodes = Array.from(currentNodes);
+      } else {
+        nextNodes = [nodeId];
+      }
+      const nextConnections = multi ? selectionRef.current.connections : [];
+      emitSelection(uniqueList(nextNodes), uniqueList(nextConnections));
+    },
+    [emitSelection]
+  );
+
+  const setSelectionRef = useRef(emitSelection);
+  useEffect(() => {
+    setSelectionRef.current = emitSelection;
+  }, [emitSelection]);
+
+  const attachConnectionHandlers = useCallback(
+    (connection: Connection, data: FlowConnection) => {
+      if (getConnectionParameter(connection, CONNECTION_HANDLERS_PARAM)) {
+        return;
+      }
+      setConnectionParameter(connection, CONNECTION_HANDLERS_PARAM, true);
+      connection.bind(EVENT_CLICK, (conn: Connection, originalEvent?: MouseEvent) => {
+        if (!originalEvent) {
+          return;
+        }
+        const multi = allowMultiSelectRef.current && (originalEvent.metaKey || originalEvent.ctrlKey || originalEvent.shiftKey);
+        const currentConnections = new Set(selectionRef.current.connections);
+        if (multi) {
+          if (currentConnections.has(data.id)) {
+            currentConnections.delete(data.id);
+          } else {
+            currentConnections.add(data.id);
+          }
+        } else {
+          currentConnections.clear();
+          currentConnections.add(data.id);
+        }
+        const nextConnections = Array.from(currentConnections);
+        const nextNodes = multi ? selectionRef.current.nodes : [];
+        setSelectionRef.current?.(uniqueList(nextNodes), uniqueList(nextConnections));
+        onLinkClickRef.current?.(data, originalEvent);
+      });
+
+      connection.bind(EVENT_DBL_CLICK, (_conn: Connection, originalEvent?: MouseEvent) => {
+        if (!originalEvent) {
+          return;
+        }
+        onLinkDoubleClickRef.current?.(data, originalEvent);
+      });
+
+      connection.bind(EVENT_MOUSEENTER, () => {
+        connection.addClass('jr-hover');
+      });
+      connection.bind(EVENT_MOUSEEXIT, () => {
+        connection.removeClass('jr-hover');
+      });
+    },
+    []
+  );
+
+  const ensureDeleteOverlay = useCallback(
+    (connection: Connection, data: FlowConnection) => {
+      const overlayId = `delete-${data.id}`;
+      if (!connection.getOverlay(overlayId)) {
+        connection.addOverlay([
+          'Custom',
+          {
+            id: overlayId,
+            location: 0.5,
+            cssClass: 'jr-connection-delete',
+            create: () => {
+              const button = document.createElement('button');
+              button.type = 'button';
+              button.className = 'jr-connection-delete-button';
+              button.innerHTML = '&times;';
+              button.addEventListener('click', (event) => {
+                event.preventDefault();
+                event.stopPropagation();
+                const connectionData = connectionMapRef.current.get(data.id);
+                if (connectionData) {
+                  onDeleteLinkRef.current?.(data);
+                }
+              });
+              return button;
+            }
+          }
+        ] as any);
+      }
+    },
+    []
+  );
+
+  const updateConnectionMetadata = useCallback(
+    (connection: Connection, data: FlowConnection) => {
+      setConnectionParameter(connection, CONNECTION_ID_PARAM, data.id);
+      const previousClass = getConnectionParameter(connection, CONNECTION_CLASS_PARAM) as string | undefined;
+      if (previousClass && previousClass !== data.className) {
+        connection.removeClass(previousClass);
+      }
+      if (data.className) {
+        connection.addClass(data.className);
+      }
+      setConnectionParameter(connection, CONNECTION_CLASS_PARAM, data.className ?? '');
+      connection.setDetachable(data.editable !== false);
+      connection.addClass('jr-connection');
+      connection.removeClass('jr-selected');
+      if (selection.connections.includes(data.id)) {
+        connection.addClass('jr-selected');
+      }
+      connection.setLabel(data.label ?? '');
+    },
+    [selection.connections]
+  );
+
+  useEffect(() => {
+    if (!graphRef.current) {
+      return;
+    }
+    const instance = newInstance({
+      container: graphRef.current,
+      elementsDraggable: !readonly,
+      dragOptions: { cursor: 'move' }
+    });
+    instanceRef.current = instance;
+    const jp = instance as unknown as {
+      bind?: (event: string, handler: (...args: any[]) => void) => void;
+      deleteConnection?: (connection: Connection, params?: any) => void;
+    };
+
+    const dragStop = (params: DragStopEventParams) => {
+      const element = params.el as HTMLElement;
+      if (!element) {
+        return;
+      }
+      const nodeId = element.getAttribute(NODE_ID_ATTRIBUTE);
+      if (!nodeId) {
+        return;
+      }
+      const [x, y] = params.finalPos;
+      onNodePositionChangeRef.current?.(nodeId, { x, y });
+    };
+
+    jp.bind?.(EVENT_DRAG_STOP, dragStop);
+
+    jp.bind?.(EVENT_CONNECTION, (info: ConnectionEstablishedParams<Element>, originalEvent?: MouseEvent) => {
+      if (syncingRef.current || !originalEvent) {
+        return;
+      }
+      const draft = toDraftConnection(info);
+      if (!draft) {
+        return;
+      }
+      const result = onLinkCreateRef.current?.(draft);
+      if (result === false) {
+        jp.deleteConnection?.(info.connection, { fireEvent: false });
+      }
+    });
+
+    jp.bind?.(EVENT_CONNECTION_DETACHED, (info: ConnectionDetachedParams<Element>) => {
+      if (syncingRef.current) {
+        return;
+      }
+      const draft = toDraftConnection(info);
+      if (!draft) {
+        return;
+      }
+      onLinkDetachedRef.current?.(draft);
+    });
+
+    return () => {
+      instance.destroy();
+      instanceRef.current = null;
+      endpointMapRef.current.clear();
+      connectionMapRef.current.clear();
+    };
+  }, [readonly]);
+
+  useEffect(() => {
+    const instance = instanceRef.current;
+    if (!instance) {
+      return;
+    }
+    const jp = instance as unknown as {
+      elementsDraggable?: boolean;
+      setDraggable?: (el: Element, draggable: boolean) => void;
+    };
+    jp.elementsDraggable = !readonly;
+    nodes.forEach((node) => {
+      const element = nodeRefs.current.get(node.id);
+      if (element) {
+        jp.setDraggable?.(element, !(readonly || node.disableDrag));
+      }
+    });
+  }, [nodes, readonly]);
+
+  useLayoutEffect(() => {
+    const instance = instanceRef.current;
+    if (!instance || !graphRef.current) {
+      return;
+    }
+    const jp = instance as unknown as {
+      batch?: (fn: () => void) => void;
+      getManagedElements?: () => Record<string, { el: Element }>;
+      unmanage?: (el: Element, removeElement?: boolean) => void;
+      setDraggable?: (el: Element, draggable: boolean) => void;
+      revalidate?: (el: Element) => void;
+      manage?: (el: Element, internalId?: string, recalc?: boolean) => void;
+    };
+    syncingRef.current = true;
+    try {
+      jp.batch?.(() => {
+        const managed = jp.getManagedElements ? jp.getManagedElements() : {};
+        const validNodeIds = new Set(nodes.map((node) => node.id));
+        Object.values(managed).forEach((entry) => {
+          const element = (entry as { el?: Element }).el as HTMLElement | undefined;
+          const nodeId = element?.getAttribute(NODE_ID_ATTRIBUTE);
+          if (nodeId && !validNodeIds.has(nodeId)) {
+            if (element) {
+              jp.unmanage?.(element, false);
+            }
+          }
+        });
+
+        nodes.forEach((node) => {
+          const element = nodeRefs.current.get(node.id);
+          if (!element) {
+            return;
+          }
+          element.setAttribute(NODE_ID_ATTRIBUTE, node.id);
+          element.style.left = `${node.position.x}px`;
+          element.style.top = `${node.position.y}px`;
+          jp.manage?.(element, node.id, true);
+          jp.setDraggable?.(element, !(readonly || node.disableDrag));
+          jp.revalidate?.(element);
+        });
+      });
+    } finally {
+      syncingRef.current = false;
+    }
+  }, [nodes, readonly]);
+
+  const synchronizeEndpoints = useCallback(() => {
+    const instance = instanceRef.current;
+    if (!instance) {
+      return;
+    }
+    const jp = instance as unknown as {
+      addEndpoint?: (el: Element, options: Record<string, unknown>) => Endpoint;
+      deleteEndpoint?: (endpoint: Endpoint) => void;
+    };
+    const nextEndpoints = new Map<string, Endpoint>();
+    nodes.forEach((node) => {
+      const element = nodeRefs.current.get(node.id);
+      if (!element) {
+        return;
+      }
+      const ports = node.ports && node.ports.length > 0 ? node.ports : ([{ id: DEFAULT_PORT_ID }] as NodePort[]);
+      ports.forEach((port) => {
+        const uuid = getEndpointUuid(node.id, port.id);
+        const portMap = portRefs.current.get(node.id);
+        const portElement = portMap?.get(port.id) ?? element;
+        if (!portElement) {
+          return;
+        }
+        let endpoint = endpointMapRef.current.get(uuid);
+        if (!endpoint) {
+          endpoint = jp.addEndpoint?.(portElement, {
+            uuid,
+            anchor: port.anchor ?? 'AutoDefault',
+            portId: port.id,
+            isSource: port.mode !== 'target',
+            isTarget: port.mode !== 'source',
+            maxConnections: -1
+          }) as Endpoint;
+        } else {
+          endpoint.setAnchor(port.anchor ?? 'AutoDefault');
+          endpoint.isSource = port.mode !== 'target';
+          endpoint.isTarget = port.mode !== 'source';
+        }
+        nextEndpoints.set(uuid, endpoint);
+      });
+    });
+
+    endpointMapRef.current.forEach((endpoint, key) => {
+      if (!nextEndpoints.has(key)) {
+        jp.deleteEndpoint?.(endpoint);
+      }
+    });
+
+    endpointMapRef.current = nextEndpoints;
+  }, [nodes]);
+
+  useLayoutEffect(() => {
+    synchronizeEndpoints();
+  }, [synchronizeEndpoints]);
+
+  useLayoutEffect(() => {
+    const instance = instanceRef.current;
+    if (!instance) {
+      return;
+    }
+    const jp = instance as unknown as {
+      batch?: (fn: () => void) => void;
+      deleteConnection?: (connection: Connection, params?: any) => void;
+      connect?: (params: Record<string, unknown>) => Connection | undefined;
+    };
+    syncingRef.current = true;
+    try {
+      jp.batch?.(() => {
+        const existing = new Map<string, Connection>();
+        const byUuid = new Map<string, Connection>();
+        flattenConnections(instance).forEach((connection) => {
+          const identifier = getConnectionParameter(connection, CONNECTION_ID_PARAM) as string | undefined;
+          if (identifier) {
+            existing.set(identifier, connection);
+          }
+          const [sourceUuid, targetUuid] = connection.getUuids();
+          byUuid.set(`${sourceUuid}|${targetUuid}`, connection);
+        });
+
+        connections.forEach((data) => {
+          const sourceUuid = getEndpointUuid(data.source.nodeId, data.source.portId);
+          const targetUuid = getEndpointUuid(data.target.nodeId, data.target.portId);
+          const sourceEndpoint = endpointMapRef.current.get(sourceUuid);
+          const targetEndpoint = endpointMapRef.current.get(targetUuid);
+          if (!sourceEndpoint || !targetEndpoint) {
+            return;
+          }
+          let connection = existing.get(data.id);
+          if (connection && !isSameUuid(connection, sourceUuid, targetUuid)) {
+            jp.deleteConnection?.(connection, { fireEvent: false });
+            connectionMapRef.current.delete(data.id);
+            connection = undefined;
+          }
+
+          if (!connection) {
+            const key = `${sourceUuid}|${targetUuid}`;
+            const reused = byUuid.get(key);
+            if (reused) {
+              connection = reused;
+              byUuid.delete(key);
+            }
+          }
+
+          if (!connection) {
+            const newConnection = jp.connect?.({
+              uuids: [sourceUuid, targetUuid],
+              detachable: data.editable !== false,
+              deleteEndpointsOnDetach: false
+            }) as Connection | undefined;
+            if (!newConnection) {
+              return;
+            }
+            attachConnectionHandlers(newConnection, data);
+            ensureDeleteOverlay(newConnection, data);
+            connection = newConnection;
+          } else {
+            attachConnectionHandlers(connection, data);
+            ensureDeleteOverlay(connection, data);
+          }
+
+          if (connection) {
+            connectionMapRef.current.set(data.id, connection);
+            updateConnectionMetadata(connection, data);
+          }
+          existing.delete(data.id);
+        });
+
+        existing.forEach((connection, id) => {
+          jp.deleteConnection?.(connection, { fireEvent: false });
+          connectionMapRef.current.delete(id);
+        });
+      });
+    } finally {
+      syncingRef.current = false;
+    }
+  }, [attachConnectionHandlers, connections, ensureDeleteOverlay, updateConnectionMetadata]);
+
+  useEffect(() => {
+    connectionMapRef.current.forEach((connection, id) => {
+      if (selection.connections.includes(id)) {
+        connection.addClass('jr-selected');
+      } else {
+        connection.removeClass('jr-selected');
+      }
+    });
+  }, [selection.connections]);
+
+  useEffect(() => {
+    nodes.forEach((node) => {
+      const element = nodeRefs.current.get(node.id);
+      if (!element) {
+        return;
+      }
+      if (selection.nodes.includes(node.id)) {
+        element.classList.add('jr-selected');
+      } else {
+        element.classList.remove('jr-selected');
+      }
+    });
+  }, [nodes, selection.nodes]);
+
+  useImperativeHandle(
+    ref,
+    () => ({
+      zoomIn: () => setZoomInternal(zoomRef.current + zoomStep),
+      zoomOut: () => setZoomInternal(zoomRef.current - zoomStep),
+      resetZoom: () => {
+        setPan({ x: 0, y: 0 });
+        setZoomInternal(1);
+      },
+      setZoom: (value: number) => {
+        setZoomInternal(value);
+      },
+      getZoom: () => zoomRef.current,
+      focusNode: (nodeId: string) => {
+        const node = nodes.find((entry) => entry.id === nodeId);
+        const element = nodeRefs.current.get(nodeId);
+        if (!node || !element || !canvasRef.current) {
+          return;
+        }
+        const canvasRect = canvasRef.current.getBoundingClientRect();
+        const rect = element.getBoundingClientRect();
+        const width = rect.width / zoomRef.current;
+        const height = rect.height / zoomRef.current;
+        const centerX = (node.position.x + width / 2) * zoomRef.current;
+        const centerY = (node.position.y + height / 2) * zoomRef.current;
+        const nextPanX = canvasRect.width / 2 - centerX;
+        const nextPanY = canvasRect.height / 2 - centerY;
+        setPan({ x: nextPanX, y: nextPanY });
+      }
+    }),
+    [nodes, setZoomInternal, zoomStep]
+  );
+
+  const handleNodeClick = useCallback(
+    (node: FlowNode, event: React.MouseEvent<HTMLDivElement>) => {
+      updateNodeSelection(node.id, event);
+      onNodeClickRef.current?.(node, event.nativeEvent);
+    },
+    [updateNodeSelection]
+  );
+
+  const handleNodeDoubleClick = useCallback((node: FlowNode, event: React.MouseEvent<HTMLDivElement>) => {
+    event.stopPropagation();
+    onNodeDoubleClickRef.current?.(node, event.nativeEvent);
+  }, []);
+
+  const handleDeleteNode = useCallback((node: FlowNode, event: React.MouseEvent<HTMLButtonElement>) => {
+    event.stopPropagation();
+    onDeleteNodeRef.current?.(node);
+  }, []);
+
+  const handleCanvasClick = useCallback(
+    (event: React.MouseEvent<HTMLDivElement>) => {
+      const target = event.target as HTMLElement;
+      if (target.closest('.jr-node') || target.closest('.jr-port') || target.closest('.jr-connection-delete-button')) {
+        return;
+      }
+      emitSelection([], []);
+      onCanvasClickRef.current?.(event.nativeEvent);
+    },
+    [emitSelection]
+  );
+
+  const registerNodeRef = useCallback((nodeId: string, element: HTMLDivElement | null) => {
+    if (element) {
+      nodeRefs.current.set(nodeId, element);
+    } else {
+      nodeRefs.current.delete(nodeId);
+    }
+  }, []);
+
+  const registerPortRef = useCallback((nodeId: string, portId: string, element: HTMLElement | null) => {
+    if (!portRefs.current.has(nodeId)) {
+      portRefs.current.set(nodeId, new Map());
+    }
+    const map = portRefs.current.get(nodeId)!;
+    if (element) {
+      map.set(portId, element);
+    } else {
+      map.delete(portId);
+    }
+  }, []);
+
+  return (
+    <div
+      ref={canvasRef}
+      className={['jr-canvas', className].filter(Boolean).join(' ')}
+      style={style}
+      onMouseDown={handleCanvasMouseDown}
+      onWheel={handleWheel}
+      onClick={handleCanvasClick}
+    >
+      <div ref={surfaceRef} className="jr-surface">
+        <div ref={graphRef} className="jr-graph">
+          {nodes.map((node) => {
+            const ports = node.ports && node.ports.length > 0 ? node.ports : ([{ id: DEFAULT_PORT_ID }] as NodePort[]);
+            const content: ReactNode = typeof node.render === 'function'
+              ? node.render({ node, selected: selection.nodes.includes(node.id), data: node.data })
+              : node.render;
+            return (
+              <div
+                key={node.id}
+                ref={(element) => registerNodeRef(node.id, element)}
+                className={['jr-node', node.className].filter(Boolean).join(' ')}
+                style={node.style as CSSProperties}
+                onClick={(event) => handleNodeClick(node, event)}
+                onDoubleClick={(event) => handleNodeDoubleClick(node, event)}
+              >
+                <div className="jr-node-body">{content}</div>
+                <button type="button" className="jr-node-delete" onClick={(event) => handleDeleteNode(node, event)}>
+                  &times;
+                </button>
+                {ports.map((port) => (
+                  <div
+                    key={port.id}
+                    ref={(element) => registerPortRef(node.id, port.id, element)}
+                    className={['jr-port', port.className, `jr-port-${port.mode ?? 'bidirectional'}`]
+                      .filter(Boolean)
+                      .join(' ')}
+                    data-port-id={port.id}
+                    style={port.style as CSSProperties}
+                  >
+                    {port.label}
+                  </div>
+                ))}
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+});
+
+FlowCanvas.displayName = 'FlowCanvas';
+
+export default FlowCanvas;

--- a/src/components/GraphNodes.tsx
+++ b/src/components/GraphNodes.tsx
@@ -1,0 +1,62 @@
+import type React from 'react';
+import type { FlowNode, NodePort } from '../types';
+import { DEFAULT_PORT_ID } from '../utils/jsPlumbHelpers';
+
+interface GraphNodesProps<TNodeData> {
+  nodes: FlowNode<TNodeData>[];
+  selectedNodeIds: string[];
+  registerNode: (nodeId: string, element: HTMLDivElement | null) => void;
+  registerPort: (nodeId: string, portId: string, element: HTMLElement | null) => void;
+  onNodeClick: (node: FlowNode<TNodeData>, event: React.MouseEvent<HTMLDivElement>) => void;
+  onNodeDoubleClick: (node: FlowNode<TNodeData>, event: React.MouseEvent<HTMLDivElement>) => void;
+  onDeleteNode: (node: FlowNode<TNodeData>, event: React.MouseEvent<HTMLButtonElement>) => void;
+}
+
+const GraphNodes = <TNodeData,>({
+  nodes,
+  selectedNodeIds,
+  registerNode,
+  registerPort,
+  onNodeClick,
+  onNodeDoubleClick,
+  onDeleteNode
+}: GraphNodesProps<TNodeData>) => (
+  <>
+    {nodes.map((node) => {
+      const ports = node.ports && node.ports.length > 0 ? node.ports : ([{ id: DEFAULT_PORT_ID }] as NodePort[]);
+      const selected = selectedNodeIds.includes(node.id);
+      const content =
+        typeof node.render === 'function'
+          ? node.render({ node, selected, data: node.data })
+          : node.render;
+      return (
+        <div
+          key={node.id}
+          ref={(element) => registerNode(node.id, element)}
+          className={['jr-node', node.className, selected ? 'jr-selected' : null].filter(Boolean).join(' ')}
+          style={node.style}
+          onClick={(event) => onNodeClick(node, event)}
+          onDoubleClick={(event) => onNodeDoubleClick(node, event)}
+        >
+          <div className="jr-node-body">{content}</div>
+          <button type="button" className="jr-node-delete" onClick={(event) => onDeleteNode(node, event)}>
+            &times;
+          </button>
+          {ports.map((port) => (
+            <div
+              key={port.id}
+              ref={(element) => registerPort(node.id, port.id, element)}
+              className={['jr-port', port.className, `jr-port-${port.mode ?? 'bidirectional'}`].filter(Boolean).join(' ')}
+              data-port-id={port.id}
+              style={port.style}
+            >
+              {port.label}
+            </div>
+          ))}
+        </div>
+      );
+    })}
+  </>
+);
+
+export default GraphNodes;

--- a/src/declarations.d.ts
+++ b/src/declarations.d.ts
@@ -1,0 +1,1 @@
+declare module '*.css';

--- a/src/dev/App.tsx
+++ b/src/dev/App.tsx
@@ -1,0 +1,205 @@
+import { useMemo, useRef, useState } from 'react';
+import {
+  FlowCanvas,
+  FlowCanvasHandle,
+  FlowConnection,
+  FlowNode,
+  DraftConnection,
+  CanvasSelection
+} from '..';
+import './app.css';
+
+const initialNodes: FlowNode[] = [
+  {
+    id: 'capture',
+    position: { x: 140, y: 160 },
+    render: ({ selected }) => (
+      <div className="node-content">
+        <h3>Capture Input</h3>
+        <p>Validate customer form data before processing.</p>
+        {selected && <span className="node-pill">Selected</span>}
+      </div>
+    ),
+    ports: [
+      { id: 'out', label: '→', mode: 'source' }
+    ]
+  },
+  {
+    id: 'enrich',
+    position: { x: 440, y: 80 },
+    render: () => (
+      <div className="node-content">
+        <h3>Enrich Profile</h3>
+        <p>Fetch CRM attributes and compute risk score.</p>
+      </div>
+    ),
+    ports: [
+      { id: 'in', label: '←', mode: 'target', style: { left: '-8px', right: 'auto', transform: 'translate(-50%, -50%)' } },
+      { id: 'out', label: '→', mode: 'source' }
+    ]
+  },
+  {
+    id: 'decision',
+    position: { x: 720, y: 240 },
+    render: ({ node }) => (
+      <div className="node-content">
+        <h3>Decision</h3>
+        <p>Route customers into nurture or upsell track.</p>
+        <span className="node-pill">{node.data?.segment ?? 'Nurture'}</span>
+      </div>
+    ),
+    data: { segment: 'Upsell' },
+    ports: [
+      { id: 'in', label: '←', mode: 'target', style: { left: '-8px', right: 'auto', transform: 'translate(-50%, -50%)' } },
+      { id: 'positive', label: '+', mode: 'source', style: { bottom: '-8px', top: 'auto', right: '50%', transform: 'translate(50%, 50%)' } },
+      { id: 'negative', label: '-', mode: 'source', style: { top: '-8px', right: '50%', transform: 'translate(50%, -50%)' } }
+    ]
+  },
+  {
+    id: 'email',
+    position: { x: 480, y: 360 },
+    render: () => (
+      <div className="node-content">
+        <h3>Email Journey</h3>
+        <p>Send onboarding sequence and collect engagement data.</p>
+      </div>
+    ),
+    ports: [
+      { id: 'in', label: '←', mode: 'target', style: { left: '-8px', right: 'auto', transform: 'translate(-50%, -50%)' } }
+    ]
+  }
+];
+
+const initialConnections: FlowConnection[] = [
+  { id: 'edge-1', source: { nodeId: 'capture', portId: 'out' }, target: { nodeId: 'enrich', portId: 'in' }, label: 'Validate' },
+  { id: 'edge-2', source: { nodeId: 'enrich', portId: 'out' }, target: { nodeId: 'decision', portId: 'in' }, label: 'Score' },
+  { id: 'edge-3', source: { nodeId: 'decision', portId: 'positive' }, target: { nodeId: 'email', portId: 'in' }, label: 'Campaign' }
+];
+
+const matchesDraft = (connection: FlowConnection, draft: DraftConnection) => {
+  const normalize = (endpoint: DraftConnection['source']) => `${endpoint.nodeId}:${endpoint.portId ?? 'default'}`;
+  return (
+    normalize(connection.source) === normalize(draft.source) &&
+    normalize(connection.target) === normalize(draft.target)
+  );
+};
+
+const App = () => {
+  const canvasRef = useRef<FlowCanvasHandle | null>(null);
+  const [nodes, setNodes] = useState<FlowNode[]>(initialNodes);
+  const [connections, setConnections] = useState<FlowConnection[]>(initialConnections);
+  const [selection, setSelection] = useState<CanvasSelection>({ nodes: [], connections: [] });
+  const [logs, setLogs] = useState<string[]>([]);
+  const connectionCounter = useRef(initialConnections.length + 1);
+
+  const addLog = (message: string) => {
+    const timestamp = new Date().toLocaleTimeString();
+    setLogs((previous) => [`[${timestamp}] ${message}`, ...previous].slice(0, 12));
+  };
+
+  const handleNodePositionChange = (nodeId: string, position: { x: number; y: number }) => {
+    setNodes((previous) =>
+      previous.map((node) => (node.id === nodeId ? { ...node, position } : node))
+    );
+    addLog(`Node ${nodeId} moved to (${Math.round(position.x)}, ${Math.round(position.y)})`);
+  };
+
+  const handleDeleteNode = (node: FlowNode) => {
+    setNodes((previous) => previous.filter((item) => item.id !== node.id));
+    setConnections((previous) =>
+      previous.filter(
+        (connection) =>
+          connection.source.nodeId !== node.id && connection.target.nodeId !== node.id
+      )
+    );
+    addLog(`Removed node ${node.id}`);
+  };
+
+  const handleDeleteLink = (connection: FlowConnection) => {
+    setConnections((previous) => previous.filter((item) => item.id !== connection.id));
+    addLog(`Removed link ${connection.id}`);
+  };
+
+  const handleLinkCreate = (draft: DraftConnection) => {
+    const id = `edge-${connectionCounter.current++}`;
+    setConnections((previous) => [
+      ...previous,
+      { id, source: draft.source, target: draft.target, label: 'New link' }
+    ]);
+    addLog(`Created link ${id}`);
+    return true;
+  };
+
+  const handleLinkDetached = (draft: DraftConnection) => {
+    setConnections((previous) => previous.filter((connection) => !matchesDraft(connection, draft)));
+    addLog(`Detached link from ${draft.source.nodeId} to ${draft.target.nodeId}`);
+  };
+
+  const focusOnSelection = () => {
+    const targetId = selection.nodes[0];
+    if (targetId) {
+      canvasRef.current?.focusNode(targetId);
+    }
+  };
+
+  const selectedSummary = useMemo(() => {
+    if (selection.nodes.length === 0 && selection.connections.length === 0) {
+      return 'Nothing selected';
+    }
+    const nodePart = selection.nodes.length > 0 ? `Nodes: ${selection.nodes.join(', ')}` : '';
+    const connectionPart = selection.connections.length > 0 ? `Links: ${selection.connections.join(', ')}` : '';
+    return [nodePart, connectionPart].filter(Boolean).join(' | ');
+  }, [selection]);
+
+  return (
+    <div className="app-shell">
+      <aside className="sidebar">
+        <h2>jsPlumb React Wrapper</h2>
+        <p className="subtitle">
+          Drag nodes, create connections and interact with the canvas to explore the API.
+        </p>
+        <div className="controls">
+          <button type="button" onClick={() => canvasRef.current?.zoomIn()}>Zoom in</button>
+          <button type="button" onClick={() => canvasRef.current?.zoomOut()}>Zoom out</button>
+          <button type="button" onClick={() => canvasRef.current?.resetZoom()}>Reset view</button>
+          <button type="button" onClick={focusOnSelection} disabled={selection.nodes.length === 0}>
+            Focus selected node
+          </button>
+        </div>
+        <div className="status-card">
+          <h3>Selection</h3>
+          <p>{selectedSummary}</p>
+        </div>
+        <div className="log-panel">
+          <h3>Activity</h3>
+          <div className="log-entries">
+            {logs.map((entry, index) => (
+              <div key={index} className="log-entry">
+                {entry}
+              </div>
+            ))}
+          </div>
+        </div>
+      </aside>
+      <main className="canvas-panel">
+        <FlowCanvas
+          ref={canvasRef}
+          nodes={nodes}
+          connections={connections}
+          onNodePositionChange={handleNodePositionChange}
+          onDeleteNode={handleDeleteNode}
+          onDeleteLink={handleDeleteLink}
+          onLinkCreate={handleLinkCreate}
+          onLinkDetached={handleLinkDetached}
+          onSelectionChange={setSelection}
+          onNodeClick={(node) => addLog(`Clicked node ${node.id}`)}
+          onNodeDoubleClick={(node) => addLog(`Double-clicked node ${node.id}`)}
+          onLinkClick={(connection) => addLog(`Clicked link ${connection.id}`)}
+          onLinkDoubleClick={(connection) => addLog(`Double-clicked link ${connection.id}`)}
+        />
+      </main>
+    </div>
+  );
+};
+
+export default App;

--- a/src/dev/app.css
+++ b/src/dev/app.css
@@ -1,0 +1,185 @@
+:root {
+  color-scheme: light;
+}
+
+html,
+body,
+#root {
+  height: 100%;
+  margin: 0;
+  background: #e2e8f0;
+}
+
+body {
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  color: #0f172a;
+}
+
+.app-shell {
+  display: grid;
+  grid-template-columns: 320px 1fr;
+  height: 100%;
+  overflow: hidden;
+}
+
+.sidebar {
+  background: rgba(255, 255, 255, 0.96);
+  border-right: 1px solid #cbd5f5;
+  padding: 24px 24px 32px;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.sidebar h2 {
+  margin: 0;
+  font-size: 22px;
+  font-weight: 700;
+  color: #1e1b4b;
+}
+
+.subtitle {
+  margin: 0;
+  font-size: 14px;
+  line-height: 1.5;
+  color: #475569;
+}
+
+.controls {
+  display: grid;
+  gap: 10px;
+}
+
+.controls button {
+  padding: 10px 14px;
+  border-radius: 8px;
+  border: none;
+  background: #4f46e5;
+  color: #fff;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.15s ease, background 0.15s ease;
+}
+
+.controls button:hover:not(:disabled) {
+  transform: translateY(-1px);
+  box-shadow: 0 10px 20px rgba(79, 70, 229, 0.25);
+}
+
+.controls button:disabled {
+  background: #cbd5f5;
+  color: #475569;
+  cursor: not-allowed;
+}
+
+.status-card {
+  background: #f8fafc;
+  border-radius: 16px;
+  padding: 16px;
+  box-shadow: inset 0 0 0 1px #e2e8f0;
+}
+
+.status-card h3 {
+  margin: 0 0 8px;
+  font-size: 15px;
+  color: #1e1b4b;
+}
+
+.status-card p {
+  margin: 0;
+  font-size: 13px;
+  color: #334155;
+}
+
+.log-panel {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  min-height: 0;
+}
+
+.log-panel h3 {
+  margin: 0;
+  font-size: 15px;
+  color: #1e1b4b;
+}
+
+.log-entries {
+  flex: 1;
+  overflow: auto;
+  padding: 12px;
+  border-radius: 12px;
+  background: #f1f5f9;
+  box-shadow: inset 0 0 0 1px #e2e8f0;
+}
+
+.log-entry {
+  font-size: 12px;
+  line-height: 1.6;
+  color: #334155;
+  padding: 4px 0;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.3);
+}
+
+.log-entry:last-child {
+  border-bottom: none;
+}
+
+.canvas-panel {
+  position: relative;
+  background: #e0e7ff;
+}
+
+.canvas-panel .jr-canvas {
+  position: absolute;
+  inset: 0;
+}
+
+.node-content {
+  pointer-events: none;
+}
+
+.node-content h3 {
+  margin: 0 0 6px;
+  font-size: 16px;
+  font-weight: 700;
+  color: #1e1b4b;
+}
+
+.node-content p {
+  margin: 0;
+  font-size: 13px;
+  line-height: 1.5;
+  color: #334155;
+}
+
+.node-pill {
+  display: inline-flex;
+  margin-top: 8px;
+  padding: 4px 8px;
+  border-radius: 9999px;
+  background: rgba(79, 70, 229, 0.15);
+  color: #312e81;
+  font-size: 12px;
+  font-weight: 600;
+}
+
+@media (max-width: 1024px) {
+  .app-shell {
+    grid-template-columns: 280px 1fr;
+  }
+}
+
+@media (max-width: 840px) {
+  .app-shell {
+    grid-template-columns: 1fr;
+  }
+  .sidebar {
+    border-right: none;
+    border-bottom: 1px solid #cbd5f5;
+  }
+  .canvas-panel {
+    min-height: 420px;
+  }
+}

--- a/src/dev/main.tsx
+++ b/src/dev/main.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/src/hooks/useJsPlumbCanvas.ts
+++ b/src/hooks/useJsPlumbCanvas.ts
@@ -1,0 +1,449 @@
+import { useCallback, useEffect, useLayoutEffect, useRef } from 'react';
+import type React from 'react';
+import { BrowserJsPlumbInstance, EVENT_DRAG_STOP, newInstance } from '@jsplumb/community';
+import type { DragStopEventParams } from '@jsplumb/community/types/browser-ui/drag-manager';
+import {
+  EVENT_CLICK,
+  EVENT_CONNECTION,
+  EVENT_CONNECTION_DETACHED,
+  EVENT_DBL_CLICK,
+  EVENT_MOUSEENTER,
+  EVENT_MOUSEEXIT,
+  Connection,
+  Endpoint
+} from '@jsplumb/core';
+import type { CanvasSelection, DraftConnection, FlowConnection, FlowNode, NodePort } from '../types';
+import { uniqueList } from '../utils/array';
+import {
+  CONNECTION_CLASS_PARAM,
+  CONNECTION_HANDLERS_PARAM,
+  CONNECTION_ID_PARAM,
+  DEFAULT_PORT_ID,
+  NODE_ID_ATTRIBUTE,
+  flattenConnections,
+  getConnectionParameter,
+  getEndpointUuid,
+  isSameUuid,
+  setConnectionParameter,
+  toDraftConnection
+} from '../utils/jsPlumbHelpers';
+
+interface UseJsPlumbCanvasOptions<TNodeData, TConnectionData> {
+  graphRef: React.RefObject<HTMLDivElement | null>;
+  nodes: FlowNode<TNodeData>[];
+  connections: FlowConnection<TConnectionData>[];
+  readonly: boolean;
+  nodeRefs: React.MutableRefObject<Map<string, HTMLDivElement>>;
+  portRefs: React.MutableRefObject<Map<string, Map<string, HTMLElement>>>;
+  instanceRef: React.MutableRefObject<BrowserJsPlumbInstance | null>;
+  selection: CanvasSelection;
+  selectionRef: React.MutableRefObject<CanvasSelection>;
+  allowMultiSelectRef: React.MutableRefObject<boolean>;
+  emitSelectionRef: React.MutableRefObject<(nodes: string[], connections: string[]) => void>;
+  onLinkClickRef: React.MutableRefObject<((connection: FlowConnection<TConnectionData>, event: MouseEvent) => void) | undefined>;
+  onLinkDoubleClickRef: React.MutableRefObject<((connection: FlowConnection<TConnectionData>, event: MouseEvent) => void) | undefined>;
+  onDeleteLinkRef: React.MutableRefObject<((connection: FlowConnection<TConnectionData>) => void) | undefined>;
+  onLinkCreateRef: React.MutableRefObject<((connection: DraftConnection) => boolean | void) | undefined>;
+  onLinkDetachedRef: React.MutableRefObject<((connection: DraftConnection) => void) | undefined>;
+  onNodePositionChangeRef: React.MutableRefObject<((nodeId: string, position: { x: number; y: number }) => void) | undefined>;
+}
+
+const useJsPlumbCanvas = <TNodeData, TConnectionData>({
+  graphRef,
+  nodes,
+  connections,
+  readonly,
+  nodeRefs,
+  portRefs,
+  instanceRef,
+  selection,
+  selectionRef,
+  allowMultiSelectRef,
+  emitSelectionRef,
+  onLinkClickRef,
+  onLinkDoubleClickRef,
+  onDeleteLinkRef,
+  onLinkCreateRef,
+  onLinkDetachedRef,
+  onNodePositionChangeRef
+}: UseJsPlumbCanvasOptions<TNodeData, TConnectionData>) => {
+  const endpointMapRef = useRef(new Map<string, Endpoint>());
+  const connectionMapRef = useRef(new Map<string, Connection>());
+  const syncingRef = useRef(false);
+
+  const attachConnectionHandlers = useCallback(
+    (connection: Connection, data: FlowConnection<TConnectionData>) => {
+      if (getConnectionParameter(connection, CONNECTION_HANDLERS_PARAM)) {
+        return;
+      }
+      setConnectionParameter(connection, CONNECTION_HANDLERS_PARAM, true);
+      connection.bind(EVENT_CLICK, (_conn: Connection, originalEvent?: MouseEvent) => {
+        if (!originalEvent) {
+          return;
+        }
+        const multi =
+          allowMultiSelectRef.current &&
+          (originalEvent.metaKey || originalEvent.ctrlKey || originalEvent.shiftKey);
+        const currentConnections = new Set(selectionRef.current.connections);
+        if (multi) {
+          if (currentConnections.has(data.id)) {
+            currentConnections.delete(data.id);
+          } else {
+            currentConnections.add(data.id);
+          }
+        } else {
+          currentConnections.clear();
+          currentConnections.add(data.id);
+        }
+        const nextConnections = Array.from(currentConnections);
+        const nextNodes = multi ? selectionRef.current.nodes : [];
+        emitSelectionRef.current?.(uniqueList(nextNodes), uniqueList(nextConnections));
+        onLinkClickRef.current?.(data, originalEvent);
+      });
+
+      connection.bind(EVENT_DBL_CLICK, (_conn: Connection, originalEvent?: MouseEvent) => {
+        if (!originalEvent) {
+          return;
+        }
+        onLinkDoubleClickRef.current?.(data, originalEvent);
+      });
+
+      connection.bind(EVENT_MOUSEENTER, () => {
+        connection.addClass('jr-hover');
+      });
+      connection.bind(EVENT_MOUSEEXIT, () => {
+        connection.removeClass('jr-hover');
+      });
+    },
+    [allowMultiSelectRef, emitSelectionRef, onLinkClickRef, onLinkDoubleClickRef, selectionRef]
+  );
+
+  const ensureDeleteOverlay = useCallback(
+    (connection: Connection, data: FlowConnection<TConnectionData>) => {
+      const overlayId = `delete-${data.id}`;
+      if (!connection.getOverlay(overlayId)) {
+        connection.addOverlay([
+          'Custom',
+          {
+            id: overlayId,
+            location: 0.5,
+            cssClass: 'jr-connection-delete',
+            create: () => {
+              const button = document.createElement('button');
+              button.type = 'button';
+              button.className = 'jr-connection-delete-button';
+              button.innerHTML = '&times;';
+              button.addEventListener('click', (event) => {
+                event.preventDefault();
+                event.stopPropagation();
+                if (connectionMapRef.current.has(data.id)) {
+                  onDeleteLinkRef.current?.(data);
+                }
+              });
+              return button;
+            }
+          }
+        ] as any);
+      }
+    },
+    [onDeleteLinkRef]
+  );
+
+  const updateConnectionMetadata = useCallback(
+    (connection: Connection, data: FlowConnection<TConnectionData>) => {
+      setConnectionParameter(connection, CONNECTION_ID_PARAM, data.id);
+      const previousClass = getConnectionParameter(connection, CONNECTION_CLASS_PARAM) as string | undefined;
+      if (previousClass && previousClass !== data.className) {
+        connection.removeClass(previousClass);
+      }
+      if (data.className) {
+        connection.addClass(data.className);
+      }
+      setConnectionParameter(connection, CONNECTION_CLASS_PARAM, data.className ?? '');
+      connection.setDetachable(data.editable !== false);
+      connection.addClass('jr-connection');
+      connection.removeClass('jr-selected');
+      if (selection.connections.includes(data.id)) {
+        connection.addClass('jr-selected');
+      }
+      connection.setLabel(data.label ?? '');
+    },
+    [selection.connections]
+  );
+
+  useEffect(() => {
+    if (!graphRef.current) {
+      return;
+    }
+    const instance = newInstance({
+      container: graphRef.current,
+      elementsDraggable: !readonly,
+      dragOptions: { cursor: 'move' }
+    });
+    instanceRef.current = instance;
+    const jp = instance as unknown as {
+      bind?: (event: string, handler: (...args: any[]) => void) => void;
+      deleteConnection?: (connection: Connection, params?: any) => void;
+    };
+
+    const dragStop = (params: DragStopEventParams) => {
+      const element = params.el as HTMLElement;
+      if (!element) {
+        return;
+      }
+      const nodeId = element.getAttribute(NODE_ID_ATTRIBUTE);
+      if (!nodeId) {
+        return;
+      }
+      const [x, y] = params.finalPos;
+      onNodePositionChangeRef.current?.(nodeId, { x, y });
+    };
+
+    jp.bind?.(EVENT_DRAG_STOP, dragStop);
+
+    jp.bind?.(EVENT_CONNECTION, (info: any, originalEvent?: MouseEvent) => {
+      if (syncingRef.current || !originalEvent) {
+        return;
+      }
+      const draft = toDraftConnection(info);
+      if (!draft) {
+        return;
+      }
+      const result = onLinkCreateRef.current?.(draft);
+      if (result === false) {
+        jp.deleteConnection?.(info.connection, { fireEvent: false });
+      }
+    });
+
+    jp.bind?.(EVENT_CONNECTION_DETACHED, (info: any) => {
+      if (syncingRef.current) {
+        return;
+      }
+      const draft = toDraftConnection(info);
+      if (!draft) {
+        return;
+      }
+      onLinkDetachedRef.current?.(draft);
+    });
+
+    return () => {
+      instance.destroy();
+      instanceRef.current = null;
+      endpointMapRef.current.clear();
+      connectionMapRef.current.clear();
+    };
+  }, [graphRef, onLinkCreateRef, onLinkDetachedRef, onNodePositionChangeRef, readonly]);
+
+  useEffect(() => {
+    const instance = instanceRef.current;
+    if (!instance) {
+      return;
+    }
+    const jp = instance as unknown as {
+      elementsDraggable?: boolean;
+      setDraggable?: (el: Element, draggable: boolean) => void;
+    };
+    jp.elementsDraggable = !readonly;
+    nodes.forEach((node) => {
+      const element = nodeRefs.current.get(node.id);
+      if (element) {
+        jp.setDraggable?.(element, !(readonly || node.disableDrag));
+      }
+    });
+  }, [nodeRefs, nodes, readonly]);
+
+  useLayoutEffect(() => {
+    const instance = instanceRef.current;
+    if (!instance || !graphRef.current) {
+      return;
+    }
+    const jp = instance as unknown as {
+      batch?: (fn: () => void) => void;
+      getManagedElements?: () => Record<string, { el: Element }>;
+      unmanage?: (el: Element, removeElement?: boolean) => void;
+      setDraggable?: (el: Element, draggable: boolean) => void;
+      revalidate?: (el: Element) => void;
+      manage?: (el: Element, internalId?: string, recalc?: boolean) => void;
+    };
+    syncingRef.current = true;
+    try {
+      jp.batch?.(() => {
+        const managed = jp.getManagedElements ? jp.getManagedElements() : {};
+        const validNodeIds = new Set(nodes.map((node) => node.id));
+        Object.values(managed).forEach((entry) => {
+          const element = (entry as { el?: Element }).el as HTMLElement | undefined;
+          const nodeId = element?.getAttribute(NODE_ID_ATTRIBUTE);
+          if (nodeId && !validNodeIds.has(nodeId)) {
+            if (element) {
+              jp.unmanage?.(element, false);
+            }
+          }
+        });
+
+        nodes.forEach((node) => {
+          const element = nodeRefs.current.get(node.id);
+          if (!element) {
+            return;
+          }
+          element.setAttribute(NODE_ID_ATTRIBUTE, node.id);
+          element.style.left = `${node.position.x}px`;
+          element.style.top = `${node.position.y}px`;
+          jp.manage?.(element, node.id, true);
+          jp.setDraggable?.(element, !(readonly || node.disableDrag));
+          jp.revalidate?.(element);
+        });
+      });
+    } finally {
+      syncingRef.current = false;
+    }
+  }, [graphRef, nodeRefs, nodes, readonly]);
+
+  const synchronizeEndpoints = useCallback(() => {
+    const instance = instanceRef.current;
+    if (!instance) {
+      return;
+    }
+    const jp = instance as unknown as {
+      addEndpoint?: (el: Element, options: Record<string, unknown>) => Endpoint;
+      deleteEndpoint?: (endpoint: Endpoint) => void;
+    };
+    const nextEndpoints = new Map<string, Endpoint>();
+    nodes.forEach((node) => {
+      const element = nodeRefs.current.get(node.id);
+      if (!element) {
+        return;
+      }
+      const ports = node.ports && node.ports.length > 0 ? node.ports : ([{ id: DEFAULT_PORT_ID }] as NodePort[]);
+      ports.forEach((port) => {
+        const uuid = getEndpointUuid(node.id, port.id);
+        const portMap = portRefs.current.get(node.id);
+        const portElement = portMap?.get(port.id) ?? element;
+        if (!portElement) {
+          return;
+        }
+        let endpoint = endpointMapRef.current.get(uuid);
+        if (!endpoint) {
+          endpoint = jp.addEndpoint?.(portElement, {
+            uuid,
+            anchor: port.anchor ?? 'AutoDefault',
+            portId: port.id,
+            isSource: port.mode !== 'target',
+            isTarget: port.mode !== 'source',
+            maxConnections: -1
+          }) as Endpoint;
+        } else {
+          endpoint.setAnchor(port.anchor ?? 'AutoDefault');
+          endpoint.isSource = port.mode !== 'target';
+          endpoint.isTarget = port.mode !== 'source';
+        }
+        nextEndpoints.set(uuid, endpoint);
+      });
+    });
+
+    endpointMapRef.current.forEach((endpoint, key) => {
+      if (!nextEndpoints.has(key)) {
+        jp.deleteEndpoint?.(endpoint);
+      }
+    });
+
+    endpointMapRef.current = nextEndpoints;
+  }, [instanceRef, nodeRefs, nodes, portRefs]);
+
+  useLayoutEffect(() => {
+    synchronizeEndpoints();
+  }, [synchronizeEndpoints]);
+
+  useLayoutEffect(() => {
+    const instance = instanceRef.current;
+    if (!instance) {
+      return;
+    }
+    const jp = instance as unknown as {
+      batch?: (fn: () => void) => void;
+      deleteConnection?: (connection: Connection, params?: any) => void;
+      connect?: (params: Record<string, unknown>) => Connection | undefined;
+    };
+    syncingRef.current = true;
+    try {
+      jp.batch?.(() => {
+        const existing = new Map<string, Connection>();
+        const byUuid = new Map<string, Connection>();
+        flattenConnections(instance).forEach((connection) => {
+          const identifier = getConnectionParameter(connection, CONNECTION_ID_PARAM) as string | undefined;
+          if (identifier) {
+            existing.set(identifier, connection);
+          }
+          const [sourceUuid, targetUuid] = connection.getUuids();
+          byUuid.set(`${sourceUuid}|${targetUuid}`, connection);
+        });
+
+        connections.forEach((data) => {
+          const sourceUuid = getEndpointUuid(data.source.nodeId, data.source.portId);
+          const targetUuid = getEndpointUuid(data.target.nodeId, data.target.portId);
+          const sourceEndpoint = endpointMapRef.current.get(sourceUuid);
+          const targetEndpoint = endpointMapRef.current.get(targetUuid);
+          if (!sourceEndpoint || !targetEndpoint) {
+            return;
+          }
+          let connection = existing.get(data.id);
+          if (connection && !isSameUuid(connection, sourceUuid, targetUuid)) {
+            jp.deleteConnection?.(connection, { fireEvent: false });
+            connectionMapRef.current.delete(data.id);
+            connection = undefined;
+          }
+
+          if (!connection) {
+            const key = `${sourceUuid}|${targetUuid}`;
+            const reused = byUuid.get(key);
+            if (reused) {
+              connection = reused;
+              byUuid.delete(key);
+            }
+          }
+
+          if (!connection) {
+            const newConnection = jp.connect?.({
+              uuids: [sourceUuid, targetUuid],
+              detachable: data.editable !== false,
+              deleteEndpointsOnDetach: false
+            }) as Connection | undefined;
+            if (!newConnection) {
+              return;
+            }
+            attachConnectionHandlers(newConnection, data);
+            ensureDeleteOverlay(newConnection, data);
+            connection = newConnection;
+          } else {
+            attachConnectionHandlers(connection, data);
+            ensureDeleteOverlay(connection, data);
+          }
+
+          if (connection) {
+            connectionMapRef.current.set(data.id, connection);
+            updateConnectionMetadata(connection, data);
+          }
+          existing.delete(data.id);
+        });
+
+        existing.forEach((connection, id) => {
+          jp.deleteConnection?.(connection, { fireEvent: false });
+          connectionMapRef.current.delete(id);
+        });
+      });
+    } finally {
+      syncingRef.current = false;
+    }
+  }, [attachConnectionHandlers, connections, ensureDeleteOverlay, instanceRef, updateConnectionMetadata]);
+
+  useEffect(() => {
+    connectionMapRef.current.forEach((connection, id) => {
+      if (selection.connections.includes(id)) {
+        connection.addClass('jr-selected');
+      } else {
+        connection.removeClass('jr-selected');
+      }
+    });
+  }, [selection.connections]);
+};
+
+export default useJsPlumbCanvas;

--- a/src/hooks/useLatest.ts
+++ b/src/hooks/useLatest.ts
@@ -1,0 +1,11 @@
+import { useEffect, useRef } from 'react';
+
+const useLatest = <T,>(value: T) => {
+  const ref = useRef(value);
+  useEffect(() => {
+    ref.current = value;
+  }, [value]);
+  return ref;
+};
+
+export default useLatest;

--- a/src/hooks/useNodeRegistry.ts
+++ b/src/hooks/useNodeRegistry.ts
@@ -1,0 +1,34 @@
+import { useCallback, useRef } from 'react';
+
+const useNodeRegistry = () => {
+  const nodeRefs = useRef(new Map<string, HTMLDivElement>());
+  const portRefs = useRef(new Map<string, Map<string, HTMLElement>>());
+
+  const registerNodeRef = useCallback((nodeId: string, element: HTMLDivElement | null) => {
+    if (element) {
+      nodeRefs.current.set(nodeId, element);
+    } else {
+      nodeRefs.current.delete(nodeId);
+      portRefs.current.delete(nodeId);
+    }
+  }, []);
+
+  const registerPortRef = useCallback((nodeId: string, portId: string, element: HTMLElement | null) => {
+    if (!portRefs.current.has(nodeId)) {
+      portRefs.current.set(nodeId, new Map());
+    }
+    const map = portRefs.current.get(nodeId)!;
+    if (element) {
+      map.set(portId, element);
+    } else {
+      map.delete(portId);
+      if (map.size === 0) {
+        portRefs.current.delete(nodeId);
+      }
+    }
+  }, []);
+
+  return { nodeRefs, portRefs, registerNodeRef, registerPortRef };
+};
+
+export default useNodeRegistry;

--- a/src/hooks/usePanZoom.ts
+++ b/src/hooks/usePanZoom.ts
@@ -1,0 +1,168 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import type React from 'react';
+import type { BrowserJsPlumbInstance } from '@jsplumb/community';
+
+interface UsePanZoomOptions {
+  canvasRef: React.RefObject<HTMLDivElement | null>;
+  surfaceRef: React.RefObject<HTMLDivElement | null>;
+  instanceRef: React.MutableRefObject<BrowserJsPlumbInstance | null>;
+  zoom?: number;
+  minZoom: number;
+  maxZoom: number;
+  zoomStep: number;
+}
+
+const usePanZoom = ({
+  canvasRef,
+  surfaceRef,
+  instanceRef,
+  zoom: zoomProp,
+  minZoom,
+  maxZoom,
+  zoomStep
+}: UsePanZoomOptions) => {
+  const [zoomState, setZoomState] = useState(zoomProp ?? 1);
+  const [pan, setPan] = useState({ x: 0, y: 0 });
+
+  const zoomRef = useRef(zoomState);
+  const panRef = useRef(pan);
+  const panStartRef = useRef<{ x: number; y: number; originX: number; originY: number } | null>(null);
+
+  useEffect(() => {
+    zoomRef.current = zoomState;
+  }, [zoomState]);
+
+  useEffect(() => {
+    panRef.current = pan;
+    if (surfaceRef.current) {
+      surfaceRef.current.style.transform = `translate(${pan.x}px, ${pan.y}px)`;
+    }
+  }, [pan, surfaceRef]);
+
+  const clampZoom = useCallback((value: number) => Math.min(maxZoom, Math.max(minZoom, value)), [maxZoom, minZoom]);
+
+  const setZoomInternal = useCallback(
+    (value: number) => {
+      const clamped = clampZoom(value);
+      setZoomState((current) => {
+        if (current === clamped) {
+          return current;
+        }
+        return clamped;
+      });
+      zoomRef.current = clamped;
+      const instance = instanceRef.current;
+      if (instance) {
+        const jp = instance as unknown as { setZoom?: (zoom: number, repaint?: boolean) => void };
+        jp.setZoom?.(clamped, true);
+      }
+      return clamped;
+    },
+    [clampZoom, instanceRef]
+  );
+
+  useEffect(() => {
+    if (typeof zoomProp === 'number') {
+      setZoomInternal(zoomProp);
+    }
+  }, [setZoomInternal, zoomProp]);
+
+  const handlePanMove = useCallback((event: MouseEvent) => {
+    const start = panStartRef.current;
+    if (!start) {
+      return;
+    }
+    const dx = event.clientX - start.x;
+    const dy = event.clientY - start.y;
+    setPan({ x: start.originX + dx, y: start.originY + dy });
+  }, []);
+
+  const handlePanEnd = useCallback(() => {
+    panStartRef.current = null;
+    window.removeEventListener('mousemove', handlePanMove);
+    window.removeEventListener('mouseup', handlePanEnd);
+  }, [handlePanMove]);
+
+  const handleCanvasMouseDown = useCallback(
+    (event: React.MouseEvent<HTMLDivElement>) => {
+      if (event.button !== 0) {
+        return;
+      }
+      const target = event.target as HTMLElement;
+      if (target.closest('.jr-node') || target.closest('.jr-port') || target.closest('.jr-connection-delete-button')) {
+        return;
+      }
+      event.preventDefault();
+      panStartRef.current = {
+        x: event.clientX,
+        y: event.clientY,
+        originX: panRef.current.x,
+        originY: panRef.current.y
+      };
+      window.addEventListener('mousemove', handlePanMove);
+      window.addEventListener('mouseup', handlePanEnd);
+    },
+    [handlePanEnd, handlePanMove]
+  );
+
+  useEffect(
+    () => () => {
+      window.removeEventListener('mousemove', handlePanMove);
+      window.removeEventListener('mouseup', handlePanEnd);
+    },
+    [handlePanEnd, handlePanMove]
+  );
+
+  const handleWheel = useCallback(
+    (event: React.WheelEvent<HTMLDivElement>) => {
+      if (!canvasRef.current) {
+        return;
+      }
+      const zoomModifier = event.ctrlKey || event.metaKey;
+      if (!zoomModifier) {
+        return;
+      }
+      event.preventDefault();
+      const canvasRect = canvasRef.current.getBoundingClientRect();
+      const pointerX = event.clientX - canvasRect.left;
+      const pointerY = event.clientY - canvasRect.top;
+      const graphX = (pointerX - panRef.current.x) / zoomRef.current;
+      const graphY = (pointerY - panRef.current.y) / zoomRef.current;
+      const direction = event.deltaY > 0 ? -1 : 1;
+      const nextZoom = setZoomInternal(zoomRef.current + direction * zoomStep);
+      const nextPanX = pointerX - graphX * nextZoom;
+      const nextPanY = pointerY - graphY * nextZoom;
+      setPan({ x: nextPanX, y: nextPanY });
+    },
+    [canvasRef, setZoomInternal, zoomStep]
+  );
+
+  const zoomIn = useCallback(() => {
+    setZoomInternal(zoomRef.current + zoomStep);
+  }, [setZoomInternal, zoomStep]);
+
+  const zoomOut = useCallback(() => {
+    setZoomInternal(zoomRef.current - zoomStep);
+  }, [setZoomInternal, zoomStep]);
+
+  const resetZoom = useCallback(() => {
+    setPan({ x: 0, y: 0 });
+    setZoomInternal(1);
+  }, [setZoomInternal]);
+
+  return {
+    zoom: zoomState,
+    zoomRef,
+    pan,
+    panRef,
+    setPan,
+    handleWheel,
+    handleCanvasMouseDown,
+    setZoom: setZoomInternal,
+    zoomIn,
+    zoomOut,
+    resetZoom
+  };
+};
+
+export default usePanZoom;

--- a/src/hooks/useSelectionManager.ts
+++ b/src/hooks/useSelectionManager.ts
@@ -1,0 +1,89 @@
+import { useCallback, useMemo, useState } from 'react';
+import type React from 'react';
+import type { CanvasSelection } from '../types';
+import { uniqueList } from '../utils/array';
+import useLatest from './useLatest';
+
+interface UseSelectionManagerOptions {
+  selectedNodes?: string[];
+  selectedConnections?: string[];
+  allowMultiSelect: boolean;
+  onSelectionChange?: (selection: CanvasSelection) => void;
+}
+
+const useSelectionManager = ({
+  selectedNodes,
+  selectedConnections,
+  allowMultiSelect,
+  onSelectionChange
+}: UseSelectionManagerOptions) => {
+  const [internalSelection, setInternalSelection] = useState<CanvasSelection>({ nodes: [], connections: [] });
+
+  const allowMultiSelectRef = useLatest(allowMultiSelect);
+  const onSelectionChangeRef = useLatest(onSelectionChange);
+
+  const selection = useMemo<CanvasSelection>(
+    () => ({
+      nodes: selectedNodes ?? internalSelection.nodes,
+      connections: selectedConnections ?? internalSelection.connections
+    }),
+    [internalSelection.connections, internalSelection.nodes, selectedConnections, selectedNodes]
+  );
+
+  const selectionRef = useLatest(selection);
+
+  const emitSelection = useCallback(
+    (nextNodes: string[], nextConnections: string[]) => {
+      setInternalSelection((previous) => ({
+        nodes: selectedNodes === undefined ? nextNodes : previous.nodes,
+        connections: selectedConnections === undefined ? nextConnections : previous.connections
+      }));
+      const finalSelection: CanvasSelection = {
+        nodes: selectedNodes ?? nextNodes,
+        connections: selectedConnections ?? nextConnections
+      };
+      onSelectionChangeRef.current?.(finalSelection);
+    },
+    [onSelectionChangeRef, selectedConnections, selectedNodes]
+  );
+
+  const emitSelectionRef = useLatest(emitSelection);
+
+  const updateNodeSelection = useCallback(
+    (nodeId: string, event: React.MouseEvent<HTMLDivElement>) => {
+      event.stopPropagation();
+      const multi = allowMultiSelectRef.current && (event.metaKey || event.ctrlKey || event.shiftKey);
+      const currentNodes = new Set(selectionRef.current.nodes);
+      let nextNodes: string[];
+      if (multi) {
+        if (currentNodes.has(nodeId)) {
+          currentNodes.delete(nodeId);
+        } else {
+          currentNodes.add(nodeId);
+        }
+        nextNodes = Array.from(currentNodes);
+      } else {
+        nextNodes = [nodeId];
+      }
+      const nextConnections = multi ? selectionRef.current.connections : [];
+      emitSelection(uniqueList(nextNodes), uniqueList(nextConnections));
+    },
+    [allowMultiSelectRef, emitSelection, selectionRef]
+  );
+
+  const clearSelection = useCallback(() => {
+    emitSelection([], []);
+  }, [emitSelection]);
+
+  return {
+    selection,
+    emitSelection,
+    emitSelectionRef,
+    selectionRef,
+    allowMultiSelectRef,
+    updateNodeSelection,
+    clearSelection
+  };
+};
+
+export default useSelectionManager;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,10 @@
+export { default as FlowCanvas } from './components/FlowCanvas';
+export type {
+  FlowCanvasHandle,
+  FlowCanvasProps,
+  FlowNode,
+  FlowConnection,
+  NodePort,
+  CanvasSelection,
+  DraftConnection
+} from './types';

--- a/src/styles/graph.css
+++ b/src/styles/graph.css
@@ -1,0 +1,160 @@
+.jr-canvas {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+  background: linear-gradient(135deg, #f8fafc 0%, #e2e8f0 100%);
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  color: #0f172a;
+}
+
+.jr-surface {
+  position: absolute;
+  inset: 0;
+  transform-origin: 0 0;
+}
+
+.jr-graph {
+  position: absolute;
+  inset: 0;
+}
+
+.jr-node {
+  position: absolute;
+  min-width: 140px;
+  padding: 12px 16px;
+  background: #ffffff;
+  border: 2px solid #cbd5f5;
+  border-radius: 12px;
+  box-shadow: 0 6px 16px rgba(15, 23, 42, 0.08);
+  cursor: pointer;
+  user-select: none;
+  transition: box-shadow 0.2s ease, border-color 0.2s ease;
+}
+
+.jr-node:hover {
+  box-shadow: 0 12px 24px rgba(15, 23, 42, 0.12);
+}
+
+.jr-node.jr-selected {
+  border-color: #4f46e5;
+  box-shadow: 0 16px 32px rgba(79, 70, 229, 0.18);
+}
+
+.jr-node-body {
+  pointer-events: none;
+  font-size: 14px;
+  font-weight: 500;
+  line-height: 1.4;
+}
+
+.jr-node-delete {
+  position: absolute;
+  top: -10px;
+  right: -10px;
+  width: 22px;
+  height: 22px;
+  border-radius: 9999px;
+  border: none;
+  background: #ef4444;
+  color: #fff;
+  font-size: 14px;
+  font-weight: bold;
+  cursor: pointer;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  box-shadow: 0 6px 18px rgba(239, 68, 68, 0.4);
+}
+
+.jr-node:hover .jr-node-delete,
+.jr-node.jr-selected .jr-node-delete {
+  display: flex;
+}
+
+.jr-port {
+  position: absolute;
+  top: 50%;
+  right: -8px;
+  width: 16px;
+  height: 16px;
+  transform: translate(50%, -50%);
+  border-radius: 50%;
+  background: #2563eb;
+  border: 2px solid #fff;
+  box-shadow: 0 4px 12px rgba(37, 99, 235, 0.4);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #0f172a;
+  font-size: 10px;
+  font-weight: 600;
+  cursor: crosshair;
+  pointer-events: auto;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.jr-port:hover {
+  transform: translate(50%, -50%) scale(1.1);
+  box-shadow: 0 6px 16px rgba(37, 99, 235, 0.45);
+}
+
+.jr-port-source {
+  background: #22c55e;
+  box-shadow: 0 4px 12px rgba(34, 197, 94, 0.4);
+}
+
+.jr-port-target {
+  background: #f97316;
+  box-shadow: 0 4px 12px rgba(249, 115, 22, 0.4);
+}
+
+.jr-port-bidirectional {
+  background: #2563eb;
+}
+
+.jr-connection path {
+  stroke: #6366f1;
+  stroke-width: 2px;
+  transition: stroke 0.2s ease, stroke-width 0.2s ease;
+}
+
+.jr-connection.jr-hover path,
+.jr-connection.jr-selected path {
+  stroke: #4338ca;
+  stroke-width: 3px;
+}
+
+.jr-connection-delete {
+  pointer-events: none;
+}
+
+.jr-connection-delete-button {
+  width: 20px;
+  height: 20px;
+  border-radius: 9999px;
+  border: none;
+  background: #ef4444;
+  color: #fff;
+  font-size: 14px;
+  font-weight: 600;
+  box-shadow: 0 6px 18px rgba(239, 68, 68, 0.4);
+  cursor: pointer;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.2s ease;
+}
+
+.jr-connection.jr-hover .jr-connection-delete-button,
+.jr-connection.jr-selected .jr-connection-delete-button {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.jr-graph .jtk-endpoint {
+  z-index: 10;
+}
+
+.jr-graph .jtk-overlay {
+  z-index: 20;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,85 @@
+import type { AnchorSpec } from '@jsplumb/core';
+import type { CSSProperties, ReactNode } from 'react';
+
+export type PortMode = 'source' | 'target' | 'bidirectional';
+
+export interface NodePort {
+  id: string;
+  label?: ReactNode;
+  anchor?: AnchorSpec;
+  mode?: PortMode;
+  className?: string;
+  style?: CSSProperties;
+}
+
+export interface FlowNode<TData = unknown> {
+  id: string;
+  position: { x: number; y: number };
+  render: ReactNode | ((context: NodeRenderContext<TData>) => ReactNode);
+  ports?: NodePort[];
+  data?: TData;
+  className?: string;
+  style?: CSSProperties;
+  disableDrag?: boolean;
+}
+
+export interface NodeRenderContext<TData> {
+  node: FlowNode<TData>;
+  selected: boolean;
+  data?: TData;
+}
+
+export interface FlowConnection<TData = unknown> {
+  id: string;
+  source: { nodeId: string; portId?: string };
+  target: { nodeId: string; portId?: string };
+  data?: TData;
+  label?: string;
+  className?: string;
+  editable?: boolean;
+}
+
+export interface DraftConnection {
+  source: { nodeId: string; portId?: string };
+  target: { nodeId: string; portId?: string };
+}
+
+export interface CanvasSelection {
+  nodes: string[];
+  connections: string[];
+}
+
+export interface FlowCanvasHandle {
+  zoomIn: () => void;
+  zoomOut: () => void;
+  resetZoom: () => void;
+  setZoom: (value: number) => void;
+  getZoom: () => number;
+  focusNode: (nodeId: string) => void;
+}
+
+export interface FlowCanvasProps<TNodeData = unknown, TConnectionData = unknown> {
+  nodes: FlowNode<TNodeData>[];
+  connections: FlowConnection<TConnectionData>[];
+  zoom?: number;
+  minZoom?: number;
+  maxZoom?: number;
+  zoomStep?: number;
+  selectedNodes?: string[];
+  selectedConnections?: string[];
+  allowMultiSelect?: boolean;
+  readonly?: boolean;
+  className?: string;
+  style?: CSSProperties;
+  onNodeClick?: (node: FlowNode<TNodeData>, event: MouseEvent) => void;
+  onNodeDoubleClick?: (node: FlowNode<TNodeData>, event: MouseEvent) => void;
+  onNodePositionChange?: (nodeId: string, position: { x: number; y: number }) => void;
+  onLinkClick?: (connection: FlowConnection<TConnectionData>, event: MouseEvent) => void;
+  onLinkDoubleClick?: (connection: FlowConnection<TConnectionData>, event: MouseEvent) => void;
+  onDeleteNode?: (node: FlowNode<TNodeData>) => void;
+  onDeleteLink?: (connection: FlowConnection<TConnectionData>) => void;
+  onLinkCreate?: (connection: DraftConnection) => boolean | void;
+  onLinkDetached?: (connection: DraftConnection) => void;
+  onSelectionChange?: (selection: CanvasSelection) => void;
+  onCanvasClick?: (event: MouseEvent) => void;
+}

--- a/src/utils/array.ts
+++ b/src/utils/array.ts
@@ -1,0 +1,1 @@
+export const uniqueList = (values: string[]) => Array.from(new Set(values));

--- a/src/utils/jsPlumbHelpers.ts
+++ b/src/utils/jsPlumbHelpers.ts
@@ -1,0 +1,72 @@
+import type { BrowserJsPlumbInstance } from '@jsplumb/community';
+import type {
+  Connection,
+  ConnectionDetachedParams,
+  ConnectionEstablishedParams
+} from '@jsplumb/core';
+import type { DraftConnection } from '../types';
+
+export const CONNECTION_ID_PARAM = 'jr-connection-id';
+export const CONNECTION_CLASS_PARAM = 'jr-connection-class';
+export const CONNECTION_HANDLERS_PARAM = 'jr-connection-handlers';
+export const NODE_ID_ATTRIBUTE = 'data-node-id';
+export const DEFAULT_PORT_ID = 'default';
+
+type ConnectionInfo = ConnectionEstablishedParams<Element> | ConnectionDetachedParams<Element>;
+
+export const flattenConnections = (instance: BrowserJsPlumbInstance): Connection[] => {
+  const jp = instance as unknown as { getConnections?: (options?: unknown, flat?: boolean) => Connection[] };
+  const connections = jp.getConnections ? jp.getConnections({}, true) : [];
+  return Array.isArray(connections) ? connections : [];
+};
+
+export const getEndpointUuid = (nodeId: string, portId?: string) => `${nodeId}:${portId ?? DEFAULT_PORT_ID}`;
+
+export const isSameUuid = (conn: Connection, source: string, target: string) => {
+  const [currentSource, currentTarget] = conn.getUuids();
+  return currentSource === source && currentTarget === target;
+};
+
+export const toDraftConnection = (info: ConnectionInfo): DraftConnection | null => {
+  const sourcePortId = info.sourceEndpoint?.portId ?? undefined;
+  const targetPortId = info.targetEndpoint?.portId ?? undefined;
+  const sourceElement = info.sourceEndpoint?.element as HTMLElement | undefined;
+  const targetElement = info.targetEndpoint?.element as HTMLElement | undefined;
+  const sourceNode = sourceElement?.closest('.jr-node') as HTMLElement | null;
+  const targetNode = targetElement?.closest('.jr-node') as HTMLElement | null;
+  const sourceNodeId = sourceNode?.getAttribute(NODE_ID_ATTRIBUTE);
+  const targetNodeId = targetNode?.getAttribute(NODE_ID_ATTRIBUTE);
+  if (!sourceNodeId || !targetNodeId) {
+    return null;
+  }
+  return {
+    source: { nodeId: sourceNodeId, portId: sourcePortId === DEFAULT_PORT_ID ? undefined : sourcePortId },
+    target: { nodeId: targetNodeId, portId: targetPortId === DEFAULT_PORT_ID ? undefined : targetPortId }
+  };
+};
+
+export const getConnectionParameter = (connection: Connection, key: string) => {
+  const withMethods = connection as unknown as {
+    getParameter?: (name: string) => unknown;
+    parameters?: Record<string, unknown>;
+  };
+  if (withMethods.getParameter) {
+    return withMethods.getParameter(key);
+  }
+  return withMethods.parameters?.[key];
+};
+
+export const setConnectionParameter = (connection: Connection, key: string, value: unknown) => {
+  const withMethods = connection as unknown as {
+    setParameter?: (name: string, value: unknown) => void;
+    parameters?: Record<string, unknown>;
+  };
+  if (withMethods.setParameter) {
+    withMethods.setParameter(key, value);
+  } else {
+    if (!withMethods.parameters) {
+      withMethods.parameters = {};
+    }
+    withMethods.parameters[key] = value;
+  }
+};

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "target": "ES2019",
+    "lib": ["DOM", "ESNext"],
+    "declaration": true,
+    "declarationDir": "dist",
+    "emitDeclarationOnly": true,
+    "esModuleInterop": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "jsx": "react-jsx",
+    "strict": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": [
+    "src/index.ts",
+    "src/components/**/*",
+    "src/hooks/**/*",
+    "src/types.ts",
+    "src/declarations.d.ts"
+  ],
+  "exclude": ["src/dev"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "types": ["vite/client"]
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.build.json" }]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,27 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+import path from 'path';
+
+export default defineConfig(({ mode }) => ({
+  plugins: [react()],
+  build: {
+    target: 'es2019',
+    lib: {
+      entry: path.resolve(__dirname, 'src/index.ts'),
+      name: 'JsPlumbReactWrapper',
+      fileName: (format) => (format === 'es' ? 'index.es.js' : 'index.cjs.js')
+    },
+    rollupOptions: {
+      external: ['react', 'react-dom'],
+      output: {
+        globals: {
+          react: 'React',
+          'react-dom': 'ReactDOM'
+        }
+      }
+    }
+  },
+  server: {
+    port: 5173
+  }
+}));


### PR DESCRIPTION
## Summary
- add a FlowCanvas component that wraps jsPlumb to render React nodes, ports, selection and interaction helpers
- define the shared TypeScript types, exports, styling and build configuration for the wrapper package
- add a Vite playground, assets and documentation that demonstrate how to use and test the library

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c9a8f99808832d9b223bef71a5a9a1